### PR TITLE
Add error information when Tenzir node fails to start

### DIFF
--- a/changelog/unreleased/01-improve-diagnostics-when-tenzir-node-fails-to-start.md
+++ b/changelog/unreleased/01-improve-diagnostics-when-tenzir-node-fails-to-start.md
@@ -1,0 +1,12 @@
+---
+title: Improve diagnostics when Tenzir Node fails to start
+type: change
+authors:
+- Alainx277
+- claude
+prs:
+- 2
+created: 2025-12-02
+---
+
+The `node` fixture now reports the exit code and stderr output when `tenzir-node` fails to start, making it easier to diagnose startup failures. Previously, the error message provided no context about why the node failed to produce an endpoint.

--- a/src/tenzir_test/fixtures/node.py
+++ b/src/tenzir_test/fixtures/node.py
@@ -213,21 +213,21 @@ def node() -> Iterator[dict[str, str]]:
             endpoint = process.stdout.readline().strip()
 
         if not endpoint:
+            # Collect diagnostic information to help debug startup failures.
+            # Note: if the process is still running (hangs without producing
+            # an endpoint), we cannot safely read stderr and diagnostics will
+            # be limited to "no additional diagnostics available".
             diagnostics: list[str] = []
-
             returncode = process.poll()
             if returncode is not None:
                 diagnostics.append(f"exit code {returncode}")
-
-            if process.stderr:
-                try:
-                    if returncode is not None:
+                if process.stderr:
+                    try:
                         stderr_output = process.stderr.read().strip()
                         if stderr_output:
                             diagnostics.append(f"stderr:\n{stderr_output}")
-                except Exception as exc:
-                    diagnostics.append(f"failed to read stderr: {exc}")
-
+                    except Exception as exc:
+                        diagnostics.append(f"failed to read stderr: {exc}")
             detail = (
                 "; ".join(diagnostics) if diagnostics else "no additional diagnostics available"
             )


### PR DESCRIPTION
Quick fix to provide diagnostic info if the node fails to start.

Might be worth considering stripping the Tenzir ASCII header, but it works either way.