### PR TITLE
Make test output verbosity opt-in with --verbose flag

### DIFF
--- a/changelog/unreleased/verbose-output-flag-for-test-results.md
+++ b/changelog/unreleased/verbose-output-flag-for-test-results.md
@@ -1,0 +1,19 @@
+---
+title: Verbose output flag for test results
+type: feature
+authors:
+  - mavam
+  - claude
+pr: 6
+created: 2026-01-23T08:51:28.134387Z
+---
+
+The `--verbose` (or `-v`) flag makes per-test output opt-in, allowing you to reduce noise in large test suites. By default, quiet mode displays only failures and a compact summary.
+
+Behavior with different flags:
+
+- **Quiet mode** (default): Hides passing and skipped tests, shows only failures and a tree summary when run with `--summary`
+- **Verbose mode** (`--verbose` / `-v`): Shows all test results as they complete, including passing and skipped tests, along with the tree summary if enabled
+- **Passthrough mode** (`--passthrough`): Automatically enables verbose output to preserve output ordering
+
+This change gives you fine-grained control over test output verbosity, making it easier to focus on what matters when running large test suites.

--- a/src/tenzir_test/cli.py
+++ b/src/tenzir_test/cli.py
@@ -137,7 +137,7 @@ def _normalize_exit_code(value: object) -> int:
     "-v",
     "--verbose",
     is_flag=True,
-    help="Print individual test results as they complete.",
+    help="Print individual test results as they complete. By default, only failures are shown. Automatically enabled in passthrough mode.",
 )
 @click.option(
     "-a",

--- a/src/tenzir_test/cli.py
+++ b/src/tenzir_test/cli.py
@@ -134,6 +134,12 @@ def _normalize_exit_code(value: object) -> int:
     help="Stream raw test output directly to the terminal.",
 )
 @click.option(
+    "-v",
+    "--verbose",
+    is_flag=True,
+    help="Print individual test results as they complete.",
+)
+@click.option(
     "-a",
     "--all-projects",
     is_flag=True,
@@ -161,6 +167,7 @@ def cli(
     keep_tmp_dirs: bool,
     jobs: int,
     passthrough: bool,
+    verbose: bool,
     all_projects: bool,
 ) -> int:
     """Execute tenzir-test scenarios."""
@@ -196,6 +203,7 @@ def cli(
             keep_tmp_dirs=keep_tmp_dirs,
             jobs=jobs,
             passthrough=passthrough,
+            verbose=verbose,
             jobs_overridden=jobs_overridden,
             all_projects=all_projects,
         )

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -308,7 +308,7 @@ def test_print_detailed_summary_outputs_tree(capsys):
 
 def test_handle_skip_uses_skip_glyph(tmp_path, capsys):
     original_root = run.ROOT
-    original_verbose = run.VERBOSE_OUTPUT
+    original_verbose = run.is_verbose_output()
     try:
         run.ROOT = tmp_path
         run.set_verbose_output(True)
@@ -328,7 +328,7 @@ def test_handle_skip_uses_skip_glyph(tmp_path, capsys):
 
 def test_success_includes_suite_suffix(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     original_root = run.ROOT
-    original_verbose = run.VERBOSE_OUTPUT
+    original_verbose = run.is_verbose_output()
     try:
         run.ROOT = tmp_path
         run.set_verbose_output(True)
@@ -339,6 +339,49 @@ def test_success_includes_suite_suffix(tmp_path: Path, capsys: pytest.CaptureFix
             run.success(test_path)
         output = capsys.readouterr().out.strip()
         assert "suite=alpha (2/3)" in output
+    finally:
+        run.ROOT = original_root
+        run.set_verbose_output(original_verbose)
+
+
+def test_handle_skip_suppressed_when_verbose_disabled(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    original_root = run.ROOT
+    original_verbose = run.is_verbose_output()
+    try:
+        run.ROOT = tmp_path
+        run.set_verbose_output(False)
+        test_path = tmp_path / "tests" / "example.tql"
+        test_path.parent.mkdir(parents=True)
+        test_path.touch()
+
+        result = run.handle_skip("slow", test_path, update=False, output_ext="txt")
+
+        assert result == "skipped"
+        output = capsys.readouterr().out.strip()
+        assert output == ""
+    finally:
+        run.ROOT = original_root
+        run.set_verbose_output(original_verbose)
+
+
+def test_success_suppressed_when_verbose_disabled(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    original_root = run.ROOT
+    original_verbose = run.is_verbose_output()
+    try:
+        run.ROOT = tmp_path
+        run.set_verbose_output(False)
+        test_path = tmp_path / "tests" / "example.tql"
+        test_path.parent.mkdir(parents=True)
+        test_path.touch()
+
+        run.success(test_path)
+
+        output = capsys.readouterr().out.strip()
+        assert output == ""
     finally:
         run.ROOT = original_root
         run.set_verbose_output(original_verbose)

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -308,8 +308,10 @@ def test_print_detailed_summary_outputs_tree(capsys):
 
 def test_handle_skip_uses_skip_glyph(tmp_path, capsys):
     original_root = run.ROOT
+    original_verbose = run.VERBOSE_OUTPUT
     try:
         run.ROOT = tmp_path
+        run.set_verbose_output(True)
         test_path = tmp_path / "tests" / "example.tql"
         test_path.parent.mkdir(parents=True)
         test_path.touch()
@@ -321,12 +323,15 @@ def test_handle_skip_uses_skip_glyph(tmp_path, capsys):
         assert output == f"{run.SKIP} skipped tests/example.tql: slow"
     finally:
         run.ROOT = original_root
+        run.set_verbose_output(original_verbose)
 
 
 def test_success_includes_suite_suffix(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     original_root = run.ROOT
+    original_verbose = run.VERBOSE_OUTPUT
     try:
         run.ROOT = tmp_path
+        run.set_verbose_output(True)
         test_path = tmp_path / "tests" / "example.tql"
         test_path.parent.mkdir(parents=True)
         test_path.touch()
@@ -336,6 +341,7 @@ def test_success_includes_suite_suffix(tmp_path: Path, capsys: pytest.CaptureFix
         assert "suite=alpha (2/3)" in output
     finally:
         run.ROOT = original_root
+        run.set_verbose_output(original_verbose)
 
 
 def test_worker_runs_suite_sequentially(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

A new `--verbose` / `-v` flag makes detailed per-test output opt-in. The new default (quiet mode) only shows failures and a compact summary, significantly reducing noise for large test suites.

### Behavior

| Mode            | Passing tests | Skipped tests | Failed tests | Tree summary             |
| --------------- | ------------- | ------------- | ------------ | ------------------------ |
| Quiet (default) | Hidden        | Hidden        | Shown        | Hidden                   |
| Verbose (`-v`)  | Shown         | Shown         | Shown        | Shown (with `--summary`) |

- Passthrough mode (`-p`) automatically enables verbose output to preserve output ordering.

### Files Modified

**Production code:**
- `src/tenzir_test/run.py` - Added `VERBOSE_OUTPUT` global state, `set_verbose_output()` and `is_verbose_output()` functions, modified `success()` and `handle_skip()` to check verbose mode, updated summary logic, added `verbose` parameter to `run_cli()` and `execute()`
- `src/tenzir_test/cli.py` - Added `-v`/`--verbose` CLI flag

**Tests:**
- `tests/test_run.py` - Updated `test_handle_skip_uses_skip_glyph` and `test_success_includes_suite_suffix` to enable verbose mode for testing

### Test Coverage

All 126 tests pass.

### Related

- Documentation: tenzir/docs#170

🤖 Generated with [Claude Code](https://claude.com/claude-code)