### PR TITLE
Fix tuple unpacking in diff_runner.py

### DIFF
--- a/changelog/unreleased/tuple-unpacking-in-diff-runner-for-multi-word-commands.md
+++ b/changelog/unreleased/tuple-unpacking-in-diff-runner-for-multi-word-commands.md
@@ -1,0 +1,11 @@
+---
+title: Tuple unpacking in diff runner for multi-word commands
+type: bugfix
+authors:
+  - mavam
+  - claude
+pr: 8
+created: 2026-01-23T17:18:03.224393Z
+---
+
+When commit 8a4686b changed `tenzir_binary` from a string to a tuple to support multi-word commands like `uvx tenzir`, one location in the diff runner was missed. The base command construction at line 69 wasn't updated to unpack the tuple, causing `expected str, bytes or os.PathLike object, not tuple` errors when running diff tests. This fix properly unpacks the binary tuple in the command list.

--- a/src/tenzir_test/runners/diff_runner.py
+++ b/src/tenzir_test/runners/diff_runner.py
@@ -66,7 +66,7 @@ class DiffRunner(TqlRunner):
                 binary = run_mod.TENZIR_BINARY
                 if not binary:
                     raise RuntimeError("TENZIR_BINARY must be configured for diff runners")
-                base_cmd: list[str] = [binary, *config_args]
+                base_cmd: list[str] = [*binary, *config_args]
 
                 if coverage:
                     coverage_dir = env.get(


### PR DESCRIPTION
## Summary

Fixes a tuple unpacking bug in `diff_runner.py` where `tenzir_binary` changed from `str | None` to `tuple[str, ...] | None` to support multi-word commands like `uvx tenzir`, but one location was missed during the refactoring.

The bug caused `expected str, bytes or os.PathLike object, not tuple` errors when running diff tests.

## Changes

- Line 69 in `src/tenzir_test/runners/diff_runner.py`: Changed `[binary, *config_args]` to `[*binary, *config_args]` to properly unpack the tuple

## Test Plan

- All 133 tests pass

Generated with Claude Code