### PR TITLE
Make debug mode imply verbose output

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,7 @@
 {
+  "env": {
+    "CLAUDE_CODE_TASK_LIST_ID": "tenzir-test"
+  },
   "extraKnownMarketplaces": {
     "tenzir": {
       "source": {

--- a/changelog/unreleased/debug-mode-implies-verbose-output.md
+++ b/changelog/unreleased/debug-mode-implies-verbose-output.md
@@ -1,0 +1,11 @@
+---
+title: Debug mode implies verbose output
+type: change
+pr: 9
+authors:
+  - mavam
+  - claude
+created: 2026-01-26T14:09:54.253909Z
+---
+
+The `--debug` flag (or `TENZIR_TEST_DEBUG=1` environment variable) now automatically enables verbose output. When debugging test failures, you now see all test results (pass/skip/fail) instead of only failures, making it easier to diagnose issues. This provides more context without requiring users to pass both `--debug` and `--verbose` flags separately.

--- a/src/tenzir_test/run.py
+++ b/src/tenzir_test/run.py
@@ -3437,7 +3437,8 @@ def run_cli(
         set_harness_mode(harness_mode)
         passthrough_mode = harness_mode is HarnessMode.PASSTHROUGH
         # Passthrough mode requires verbose output to show real-time test results
-        set_verbose_output(verbose or passthrough_mode)
+        # Debug mode also implies verbose to show all test results when diagnosing
+        set_verbose_output(verbose or passthrough_mode or debug_enabled)
         if passthrough_mode and jobs > 1:
             if jobs_overridden:
                 print(f"{INFO} forcing --jobs=1 in passthrough mode to preserve output ordering")


### PR DESCRIPTION
## Summary
- Make `--debug` imply `--verbose` output automatically
- When debugging, users want to see all test results, not just failures

## Test plan
- [ ] Run tests with only `--debug`: should show all test results (pass/skip/fail)
- [ ] Run tests with only `--verbose`: should show all test results (unchanged behavior)
- [ ] Run tests with neither flag: should show only failures (unchanged behavior)
- [ ] Run tests with `TENZIR_TEST_DEBUG=1`: should show all test results

## Related
- Documentation PR: https://github.com/tenzir/docs/pull/176

🤖 Generated with [Claude Code](https://claude.com/claude-code)