### PR TITLE
Add name-based test selection via -m/--match

### DIFF
--- a/changelog/unreleased/test-selection-by-name-pattern-matching.md
+++ b/changelog/unreleased/test-selection-by-name-pattern-matching.md
@@ -1,0 +1,13 @@
+---
+title: Test selection by name pattern matching
+type: feature
+authors:
+  - mavam
+  - claude
+pr: 13
+created: 2026-02-06T13:58:03.880898Z
+---
+
+Select tests by relative path using the new `-m`/`--match` option with fnmatch glob patterns. You can repeat the option to match multiple patterns, and tests matching any pattern are selected. When you combine TEST paths with `-m` patterns, the framework runs only tests matching both (intersection). If a matched test belongs to a suite configured via `test.yaml`, all tests in that suite are included automatically. Empty or whitespace-only patterns are silently ignored.
+
+Example: `tenzir-test -m '*context*' -m '*create*'` runs all tests whose paths contain "context" or "create" anywhere in the name.

--- a/src/tenzir_test/cli.py
+++ b/src/tenzir_test/cli.py
@@ -38,9 +38,9 @@ Examples:
   tenzir-test                          Run all tests in the project
   tenzir-test tests/alerts/            Run all tests in a directory
   tenzir-test tests/basic.tql          Run a specific test file
-  tenzir-test -m '*ctx*'               Run tests matching a name pattern
+  tenzir-test -m '*ctx*'               Run tests matching a path pattern
   tenzir-test -m '*add*' -m '*del*'    Run tests matching either pattern
-  tenzir-test tests/ctx/ -m '*create*' Filter a directory by pattern
+  tenzir-test tests/ctx/ -m '*create*' Intersect directory with pattern
   tenzir-test -u tests/new.tql         Run test and update its baseline
   tenzir-test -p -k tests/debug/       Debug with output streaming and kept temps
 
@@ -165,8 +165,12 @@ Documentation: https://docs.tenzir.com/reference/test-framework/
     type=str,
     help=(
         "Run tests whose relative path matches a glob pattern (fnmatch syntax). "
+        "Useful for selecting tests by name across different directories. "
         "Repeatable; tests matching any pattern are selected. "
-        "Combined with TEST paths, only tests matching both are run."
+        "If TEST paths are also given, only tests matching both the path and "
+        "pattern are run (intersection). "
+        "Note: if a matched test belongs to a suite (configured via test.yaml), "
+        "all tests in that suite are included automatically."
     ),
 )
 @click.pass_context
@@ -204,10 +208,12 @@ def cli(
       - Directories to run all tests within (e.g., tests/alerts/)
       - Omitted to run all discovered tests in the project
 
-    Use -m/--match to select tests by name pattern (fnmatch glob syntax).
+    Use -m/--match to select tests by glob pattern (fnmatch syntax).
     Patterns match against relative paths shown in test output.
     When both TEST paths and -m patterns are given, only tests matching both
-    are run (intersection).
+    are run (intersection). Empty pattern strings are silently ignored.
+    If a matched test belongs to a suite (configured via test.yaml), all
+    tests in that suite are included automatically.
     """
 
     package_paths: list[Path] = []

--- a/src/tenzir_test/cli.py
+++ b/src/tenzir_test/cli.py
@@ -35,14 +35,14 @@ def _normalize_exit_code(value: object) -> int:
     context_settings={"help_option_names": ["-h", "--help"]},
     epilog="""\
 Examples:
-  tenzir-test                             Run all tests in the project
-  tenzir-test tests/alerts/               Run all tests in a directory
-  tenzir-test tests/basic.tql             Run a specific test file
-  tenzir-test -m '*context*'              Run tests matching a name pattern
-  tenzir-test -m '*create*' -m '*update*' Run tests matching either pattern
-  tenzir-test tests/foo.tql -m '*bar*'    Merge path and pattern selections
-  tenzir-test -u tests/new.tql            Run test and update its baseline
-  tenzir-test -p -k tests/debug/          Debug with output streaming and kept temps
+  tenzir-test                          Run all tests in the project
+  tenzir-test tests/alerts/            Run all tests in a directory
+  tenzir-test tests/basic.tql          Run a specific test file
+  tenzir-test -m '*ctx*'               Run tests matching a name pattern
+  tenzir-test -m '*add*' -m '*del*'    Run tests matching either pattern
+  tenzir-test tests/ctx/ -m '*create*' Filter a directory by pattern
+  tenzir-test -u tests/new.tql         Run test and update its baseline
+  tenzir-test -p -k tests/debug/       Debug with output streaming and kept temps
 
 Documentation: https://docs.tenzir.com/reference/test-framework/
 """,
@@ -166,7 +166,7 @@ Documentation: https://docs.tenzir.com/reference/test-framework/
     help=(
         "Run tests whose relative path matches a glob pattern (fnmatch syntax). "
         "Repeatable; tests matching any pattern are selected. "
-        "Combined with TEST paths, both selections are merged."
+        "Combined with TEST paths, only tests matching both are run."
     ),
 )
 @click.pass_context
@@ -206,7 +206,8 @@ def cli(
 
     Use -m/--match to select tests by name pattern (fnmatch glob syntax).
     Patterns match against relative paths shown in test output.
-    When both TEST paths and -m patterns are given, their selections are merged.
+    When both TEST paths and -m patterns are given, only tests matching both
+    are run (intersection).
     """
 
     package_paths: list[Path] = []

--- a/src/tenzir_test/cli.py
+++ b/src/tenzir_test/cli.py
@@ -35,11 +35,14 @@ def _normalize_exit_code(value: object) -> int:
     context_settings={"help_option_names": ["-h", "--help"]},
     epilog="""\
 Examples:
-  tenzir-test                       Run all tests in the project
-  tenzir-test tests/alerts/         Run all tests in a directory
-  tenzir-test tests/basic.tql       Run a specific test file
-  tenzir-test -u tests/new.tql      Run test and update its baseline
-  tenzir-test -p -k tests/debug/    Debug with output streaming and kept temps
+  tenzir-test                             Run all tests in the project
+  tenzir-test tests/alerts/               Run all tests in a directory
+  tenzir-test tests/basic.tql             Run a specific test file
+  tenzir-test -m '*context*'              Run tests matching a name pattern
+  tenzir-test -m '*create*' -m '*update*' Run tests matching either pattern
+  tenzir-test tests/foo.tql -m '*bar*'    Merge path and pattern selections
+  tenzir-test -u tests/new.tql            Run test and update its baseline
+  tenzir-test -p -k tests/debug/          Debug with output streaming and kept temps
 
 Documentation: https://docs.tenzir.com/reference/test-framework/
 """,
@@ -154,6 +157,18 @@ Documentation: https://docs.tenzir.com/reference/test-framework/
     is_flag=True,
     help="Run the root project alongside any selected satellites.",
 )
+@click.option(
+    "-m",
+    "--match",
+    "match_patterns",
+    multiple=True,
+    type=str,
+    help=(
+        "Run tests whose relative path matches a glob pattern (fnmatch syntax). "
+        "Repeatable; tests matching any pattern are selected. "
+        "Combined with TEST paths, both selections are merged."
+    ),
+)
 @click.pass_context
 def cli(
     ctx: click.Context,
@@ -161,6 +176,7 @@ def cli(
     root: Path | None,
     package_dirs: tuple[str, ...],
     tests: tuple[Path, ...],
+    match_patterns: tuple[str, ...],
     update: bool,
     debug: bool,
     purge: bool,
@@ -187,6 +203,10 @@ def cli(
       - Individual test files (e.g., tests/basic.tql)
       - Directories to run all tests within (e.g., tests/alerts/)
       - Omitted to run all discovered tests in the project
+
+    Use -m/--match to select tests by name pattern (fnmatch glob syntax).
+    Patterns match against relative paths shown in test output.
+    When both TEST paths and -m patterns are given, their selections are merged.
     """
 
     package_paths: list[Path] = []
@@ -221,6 +241,7 @@ def cli(
             verbose=verbose,
             jobs_overridden=jobs_overridden,
             all_projects=all_projects,
+            match_patterns=list(match_patterns),
         )
     except runtime.HarnessError as exc:
         if exc.show_message and exc.args:

--- a/src/tenzir_test/run.py
+++ b/src/tenzir_test/run.py
@@ -3862,23 +3862,15 @@ def run_cli(
                 if match_patterns:
                     active_patterns = [p for p in match_patterns if p]
                     if active_patterns:
-                        if selection.run_all:
-                            collected_paths = _filter_paths_by_patterns(
-                                collected_paths,
-                                active_patterns,
-                                project_root=selection.root,
-                            )
-                        else:
-                            all_project_paths: set[Path] = set()
-                            for tests_dir in _iter_project_test_directories(selection.root):
-                                for test_path in collect_all_tests(tests_dir):
-                                    all_project_paths.add(test_path.resolve())
-                            pattern_matched = _filter_paths_by_patterns(
-                                all_project_paths,
-                                active_patterns,
-                                project_root=selection.root,
-                            )
-                            collected_paths |= pattern_matched
+                        # Filter collected tests to those matching the
+                        # patterns.  When path args are given this is an
+                        # intersection; without path args it filters all
+                        # discovered tests.
+                        collected_paths = _filter_paths_by_patterns(
+                            collected_paths,
+                            active_patterns,
+                            project_root=selection.root,
+                        )
                         collected_paths = _expand_suites(collected_paths)
                         if not collected_paths:
                             print(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -191,6 +191,48 @@ def test_cli_version_flag(capsys: pytest.CaptureFixture[str]) -> None:
     assert captured.err == ""
 
 
+def test_cli_match_flag(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_run_cli(**kwargs: object) -> run.ExecutionResult:
+        captured.update(kwargs)
+        return _make_result()
+
+    monkeypatch.setattr(cli.runtime, "run_cli", fake_run_cli)
+
+    assert cli.main(["-m", "*context*"]) == 0
+    assert captured["match_patterns"] == ["*context*"]
+
+
+def test_cli_multiple_match_flags(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_run_cli(**kwargs: object) -> run.ExecutionResult:
+        captured.update(kwargs)
+        return _make_result()
+
+    monkeypatch.setattr(cli.runtime, "run_cli", fake_run_cli)
+
+    assert cli.main(["-m", "*create*", "-m", "*update*"]) == 0
+    assert captured["match_patterns"] == ["*create*", "*update*"]
+
+
+def test_cli_match_with_path_args(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_run_cli(**kwargs: object) -> run.ExecutionResult:
+        captured.update(kwargs)
+        return _make_result()
+
+    monkeypatch.setattr(cli.runtime, "run_cli", fake_run_cli)
+
+    from pathlib import Path
+
+    assert cli.main(["tests/foo.tql", "-m", "*bar*"]) == 0
+    assert captured["match_patterns"] == ["*bar*"]
+    assert captured["tests"] == [Path("tests/foo.tql")]
+
+
 def test_cli_unknown_option(capsys: pytest.CaptureFixture[str]) -> None:
     exit_code = cli.main(["--details"])
     assert exit_code == 2

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -2760,7 +2760,7 @@ class TestMatchPatternIntegration:
         root = info["root"]
 
         # Create a satellite project inside the root project directory.
-        satellite = _make_satellite_project(root, "satellite", ["create", "list"])
+        _make_satellite_project(root, "satellite", ["create", "list"])
         monkeypatch.chdir(root)
 
         try:
@@ -2793,7 +2793,7 @@ class TestMatchPatternIntegration:
         info = self._setup_project(tmp_path)
         root = info["root"]
 
-        satellite = _make_satellite_project(root, "satellite", ["deploy", "list"])
+        _make_satellite_project(root, "satellite", ["deploy", "list"])
         monkeypatch.chdir(root)
 
         try:

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -2258,62 +2258,178 @@ class TestFilterPathsByPatterns:
         root = tmp_path / "project"
         tests_dir = root / "tests"
         tests_dir.mkdir(parents=True)
-        a = tests_dir / "context-create.tql"
-        b = tests_dir / "context-update.tql"
-        c = tests_dir / "other.tql"
-        for f in (a, b, c):
+        context_create = tests_dir / "context-create.tql"
+        context_update = tests_dir / "context-update.tql"
+        non_matching = tests_dir / "other.tql"
+        for f in (context_create, context_update, non_matching):
             f.touch()
 
-        result = run._filter_paths_by_patterns({a, b, c}, ["*context*"], project_root=root)
-        assert result == {a, b}
+        result = run._filter_paths_by_patterns(
+            {context_create, context_update, non_matching},
+            ["*context*"],
+            project_root=root,
+        )
+        assert result == {context_create, context_update}
 
     def test_or_semantics(self, tmp_path: Path) -> None:
         root = tmp_path / "project"
         tests_dir = root / "tests"
         tests_dir.mkdir(parents=True)
-        a = tests_dir / "create.tql"
-        b = tests_dir / "update.tql"
-        c = tests_dir / "delete.tql"
-        for f in (a, b, c):
+        create = tests_dir / "create.tql"
+        update = tests_dir / "update.tql"
+        delete = tests_dir / "delete.tql"
+        for f in (create, update, delete):
             f.touch()
 
         result = run._filter_paths_by_patterns(
-            {a, b, c}, ["*create*", "*delete*"], project_root=root
+            {create, update, delete}, ["*create*", "*delete*"], project_root=root
         )
-        assert result == {a, c}
+        assert result == {create, delete}
 
     def test_no_match(self, tmp_path: Path) -> None:
         root = tmp_path / "project"
         tests_dir = root / "tests"
         tests_dir.mkdir(parents=True)
-        a = tests_dir / "foo.tql"
-        a.touch()
+        foo = tests_dir / "foo.tql"
+        foo.touch()
 
-        result = run._filter_paths_by_patterns({a}, ["*nonexistent*"], project_root=root)
+        result = run._filter_paths_by_patterns({foo}, ["*nonexistent*"], project_root=root)
         assert result == set()
 
     def test_empty_patterns_skipped(self, tmp_path: Path) -> None:
         root = tmp_path / "project"
         tests_dir = root / "tests"
         tests_dir.mkdir(parents=True)
-        a = tests_dir / "foo.tql"
-        a.touch()
+        foo = tests_dir / "foo.tql"
+        foo.touch()
 
-        result = run._filter_paths_by_patterns({a}, ["", "  ", "*foo*"], project_root=root)
-        assert result == {a}
+        result = run._filter_paths_by_patterns({foo}, ["", "  ", "*foo*"], project_root=root)
+        assert result == {foo}
 
     def test_case_sensitive(self, tmp_path: Path) -> None:
         root = tmp_path / "project"
         tests_dir = root / "tests"
         tests_dir.mkdir(parents=True)
-        a = tests_dir / "Foo.tql"
-        a.touch()
+        capitalized_foo = tests_dir / "Foo.tql"
+        capitalized_foo.touch()
 
-        result = run._filter_paths_by_patterns({a}, ["*foo*"], project_root=root)
+        result = run._filter_paths_by_patterns({capitalized_foo}, ["*foo*"], project_root=root)
         assert result == set()
 
-        result = run._filter_paths_by_patterns({a}, ["*Foo*"], project_root=root)
-        assert result == {a}
+        result = run._filter_paths_by_patterns({capitalized_foo}, ["*Foo*"], project_root=root)
+        assert result == {capitalized_foo}
+
+    def test_question_mark_wildcard(self, tmp_path: Path) -> None:
+        root = tmp_path / "project"
+        tests_dir = root / "tests"
+        tests_dir.mkdir(parents=True)
+        single_digit = tests_dir / "test1.tql"
+        single_digit_2 = tests_dir / "test2.tql"
+        double_digit = tests_dir / "test10.tql"
+        for f in (single_digit, single_digit_2, double_digit):
+            f.touch()
+
+        result = run._filter_paths_by_patterns(
+            {single_digit, single_digit_2, double_digit},
+            ["*test?.tql"],
+            project_root=root,
+        )
+        # ? matches exactly one character, so test10.tql should not match
+        assert result == {single_digit, single_digit_2}
+
+    def test_bracket_expression(self, tmp_path: Path) -> None:
+        root = tmp_path / "project"
+        tests_dir = root / "tests"
+        tests_dir.mkdir(parents=True)
+        test0 = tests_dir / "test0.tql"
+        test1 = tests_dir / "test1.tql"
+        test2 = tests_dir / "test2.tql"
+        test_x = tests_dir / "testX.tql"
+        for f in (test0, test1, test2, test_x):
+            f.touch()
+
+        result = run._filter_paths_by_patterns(
+            {test0, test1, test2, test_x}, ["*test[12].tql"], project_root=root
+        )
+        # [12] matches '1' or '2' only
+        assert result == {test1, test2}
+
+    def test_negated_bracket_expression(self, tmp_path: Path) -> None:
+        root = tmp_path / "project"
+        tests_dir = root / "tests"
+        tests_dir.mkdir(parents=True)
+        test0 = tests_dir / "test0.tql"
+        test1 = tests_dir / "test1.tql"
+        test2 = tests_dir / "test2.tql"
+        for f in (test0, test1, test2):
+            f.touch()
+
+        result = run._filter_paths_by_patterns(
+            {test0, test1, test2}, ["*test[!0].tql"], project_root=root
+        )
+        # [!0] matches any single character except '0'
+        assert result == {test1, test2}
+
+    def test_bracket_range(self, tmp_path: Path) -> None:
+        root = tmp_path / "project"
+        tests_dir = root / "tests"
+        tests_dir.mkdir(parents=True)
+        files = [tests_dir / f"test{i}.tql" for i in range(5)]
+        for f in files:
+            f.touch()
+
+        result = run._filter_paths_by_patterns(set(files), ["*test[1-3].tql"], project_root=root)
+        # [1-3] matches '1', '2', or '3'
+        assert result == {files[1], files[2], files[3]}
+
+    def test_symlink_outside_root_excluded(self, tmp_path: Path) -> None:
+        """A symlink resolving outside the project root is silently excluded."""
+        import os
+
+        root = tmp_path / "project"
+        tests_dir = root / "tests"
+        tests_dir.mkdir(parents=True)
+
+        # Create a real test file inside the project
+        real_test = tests_dir / "legit.tql"
+        real_test.touch()
+
+        # Create a file outside the project
+        outside_file = tmp_path / "outside" / "sneaky.tql"
+        outside_file.parent.mkdir(parents=True)
+        outside_file.touch()
+
+        # Create a symlink inside the project that points outside
+        symlink_test = tests_dir / "sneaky.tql"
+        os.symlink(str(outside_file), str(symlink_test))
+
+        # The symlink matches the pattern but resolves outside the root,
+        # so _filter_paths_by_patterns must exclude it.
+        result = run._filter_paths_by_patterns(
+            {real_test, symlink_test}, ["*sneaky*"], project_root=root
+        )
+        assert result == set()
+
+    def test_symlink_inside_root_included(self, tmp_path: Path) -> None:
+        """A symlink resolving within the project root is included normally."""
+        import os
+
+        root = tmp_path / "project"
+        tests_dir = root / "tests"
+        shared_dir = root / "shared"
+        tests_dir.mkdir(parents=True)
+        shared_dir.mkdir(parents=True)
+
+        # Create a real file inside the project
+        shared_file = shared_dir / "common.tql"
+        shared_file.touch()
+
+        # Create a symlink inside the project pointing to another file inside the project
+        symlink_test = tests_dir / "common.tql"
+        os.symlink(str(shared_file), str(symlink_test))
+
+        result = run._filter_paths_by_patterns({symlink_test}, ["*common*"], project_root=root)
+        assert result == {symlink_test}
 
 
 # Tests for _expand_suites
@@ -2337,21 +2453,21 @@ class TestExpandSuites:
         suite_dir = tmp_path / "tests" / "context"
         suite_dir.mkdir(parents=True)
         (suite_dir / "test.yaml").write_text("suite: context\n", encoding="utf-8")
-        a = suite_dir / "01-create.tql"
-        b = suite_dir / "02-update.tql"
-        c = suite_dir / "03-delete.tql"
-        for f in (a, b, c):
+        suite_create = suite_dir / "01-create.tql"
+        suite_update = suite_dir / "02-update.tql"
+        suite_delete = suite_dir / "03-delete.tql"
+        for f in (suite_create, suite_update, suite_delete):
             f.write_text("version\n", encoding="utf-8")
 
         run._clear_directory_config_cache()
         run.refresh_runner_metadata()
 
         try:
-            result = run._expand_suites({a.resolve()})
+            result = run._expand_suites({suite_create.resolve()})
             resolved = {p.resolve() for p in result}
-            assert a.resolve() in resolved
-            assert b.resolve() in resolved
-            assert c.resolve() in resolved
+            assert suite_create.resolve() in resolved
+            assert suite_update.resolve() in resolved
+            assert suite_delete.resolve() in resolved
         finally:
             run._clear_directory_config_cache()
             run.apply_settings(original_settings)
@@ -2372,14 +2488,326 @@ class TestExpandSuites:
 
         tests_dir = tmp_path / "tests"
         tests_dir.mkdir(parents=True)
-        a = tests_dir / "standalone.tql"
-        a.write_text("version\n", encoding="utf-8")
+        standalone = tests_dir / "standalone.tql"
+        standalone.write_text("version\n", encoding="utf-8")
 
         run._clear_directory_config_cache()
 
         try:
-            result = run._expand_suites({a.resolve()})
-            assert result == {a.resolve()}
+            result = run._expand_suites({standalone.resolve()})
+            assert result == {standalone.resolve()}
         finally:
             run._clear_directory_config_cache()
             run.apply_settings(original_settings)
+
+    def test_pattern_filtered_non_suite_paths_unchanged(self, tmp_path: Path) -> None:
+        """Matching non-suite tests by pattern and expanding keeps the set unchanged."""
+        original_settings = config.Settings(
+            root=run.ROOT,
+            tenzir_binary=run.TENZIR_BINARY,
+            tenzir_node_binary=run.TENZIR_NODE_BINARY,
+        )
+        run.apply_settings(
+            config.Settings(
+                root=tmp_path,
+                tenzir_binary=run.TENZIR_BINARY,
+                tenzir_node_binary=run.TENZIR_NODE_BINARY,
+            )
+        )
+
+        standalone_dir = tmp_path / "tests" / "standalone"
+        standalone_dir.mkdir(parents=True)
+        foo = standalone_dir / "foo.tql"
+        bar = standalone_dir / "bar.tql"
+        for f in (foo, bar):
+            f.write_text("version\n", encoding="utf-8")
+
+        run._clear_directory_config_cache()
+
+        try:
+            # Filter by pattern so only foo.tql is selected.
+            filtered = run._filter_paths_by_patterns(
+                [foo.resolve(), bar.resolve()],
+                ["*foo*"],
+                project_root=tmp_path,
+            )
+            assert filtered == {foo.resolve()}
+
+            # Expanding suites should return the same set since there is no suite.
+            result = run._expand_suites(filtered)
+            assert result == {foo.resolve()}
+        finally:
+            run._clear_directory_config_cache()
+            run.apply_settings(original_settings)
+
+
+def _make_project(tmp_path: Path) -> dict[str, Path]:
+    """Create a minimal project with test files in multiple directories.
+
+    Returns a dict mapping short names to the created .tql file paths.
+    """
+    project = tmp_path / "project"
+    tests_dir = project / "tests"
+    ctx_dir = tests_dir / "ctx"
+    other_dir = tests_dir / "other"
+    ctx_dir.mkdir(parents=True)
+    other_dir.mkdir(parents=True)
+    # Create ancillary directories so _is_project_root succeeds.
+    (project / "fixtures").mkdir(parents=True, exist_ok=True)
+    (project / "fixtures" / "__init__.py").write_text("", encoding="utf-8")
+    (project / "runners").mkdir(parents=True, exist_ok=True)
+    (project / "runners" / "__init__.py").write_text("", encoding="utf-8")
+    (project / "inputs").mkdir(parents=True, exist_ok=True)
+
+    files: dict[str, Path] = {}
+    for name, parent in [
+        ("ctx_create", ctx_dir),
+        ("ctx_delete", ctx_dir),
+        ("other_create", other_dir),
+    ]:
+        tql = parent / f"{name.split('_', 1)[1]}.tql"
+        tql.write_text("version\n", encoding="utf-8")
+        files[name] = tql
+    return {"root": project, **files}
+
+
+def _make_satellite_project(parent: Path, name: str, test_names: list[str]) -> Path:
+    """Create a minimal satellite project under *parent* with the given test files.
+
+    Returns the satellite project root.
+    """
+    satellite = parent / name
+    tests_dir = satellite / "tests"
+    tests_dir.mkdir(parents=True)
+    for test_name in test_names:
+        tql = tests_dir / f"{test_name}.tql"
+        tql.write_text("version\n", encoding="utf-8")
+    return satellite
+
+
+def _run_cli_kwargs(
+    root: Path,
+    *,
+    tests: list[Path] | None = None,
+    match_patterns: tuple[str, ...] = (),
+    all_projects: bool = False,
+) -> dict:
+    """Return the full set of keyword arguments for ``run.run_cli``."""
+    return dict(
+        root=root,
+        tests=tests or [],
+        update=False,
+        debug=False,
+        purge=False,
+        coverage=False,
+        coverage_source_dir=None,
+        runner_summary=False,
+        fixture_summary=False,
+        show_summary=False,
+        show_diff_output=True,
+        show_diff_stat=True,
+        jobs=1,
+        keep_tmp_dirs=False,
+        passthrough=False,
+        jobs_overridden=False,
+        all_projects=all_projects,
+        match_patterns=match_patterns,
+    )
+
+
+class TestMatchPatternIntegration:
+    """Integration tests for -m/--match pattern filtering through ``run_cli``."""
+
+    @staticmethod
+    def _setup_project(tmp_path: Path) -> dict[str, Path]:
+        info = _make_project(tmp_path)
+        original_settings = config.Settings(
+            root=run.ROOT,
+            tenzir_binary=run.TENZIR_BINARY,
+            tenzir_node_binary=run.TENZIR_NODE_BINARY,
+        )
+        run.apply_settings(
+            config.Settings(
+                root=info["root"],
+                tenzir_binary=run.TENZIR_BINARY,
+                tenzir_node_binary=run.TENZIR_NODE_BINARY,
+            )
+        )
+        run.refresh_runner_metadata()
+        info["_original_settings"] = original_settings
+        return info
+
+    @staticmethod
+    def _teardown(info: dict) -> None:
+        run._clear_directory_config_cache()
+        run.apply_settings(info["_original_settings"])
+
+    # -- intersection: path args + match patterns -------------------------
+
+    def test_intersection_filters_to_matching_subset(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """When both TEST paths and -m patterns are given, only tests matching
+        both are collected (intersection semantics).
+
+        The ctx/ directory contains create.tql and delete.tql.  Intersecting
+        with ``*create*`` should collect only create.tql (queue_size == 1).
+        """
+        info = self._setup_project(tmp_path)
+        ctx_dir = info["root"] / "tests" / "ctx"
+        try:
+            result = run.run_cli(
+                **_run_cli_kwargs(
+                    info["root"],
+                    tests=[ctx_dir],
+                    match_patterns=("*create*",),
+                )
+            )
+            # Exactly one test should have been collected: ctx/create.tql.
+            # ctx/delete.tql is in the path but does not match the pattern;
+            # other/create.tql matches the pattern but is outside the path.
+            assert result.queue_size == 1
+            assert result.summary.total == 1
+        finally:
+            self._teardown(info)
+
+    def test_intersection_no_match_reports_empty(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """When the intersection of path args and pattern is empty, no tests
+        are collected and the user sees an informative message that clarifies
+        the intersection semantics."""
+        info = self._setup_project(tmp_path)
+        ctx_dir = info["root"] / "tests" / "ctx"
+        try:
+            result = run.run_cli(
+                **_run_cli_kwargs(
+                    info["root"],
+                    tests=[ctx_dir],
+                    match_patterns=("*nonexistent*",),
+                )
+            )
+            assert result.queue_size == 0
+            output = capsys.readouterr().out
+            assert "no tests matched pattern(s)" in output
+            assert "within the selected paths" in output
+        finally:
+            self._teardown(info)
+
+    # -- pattern-only: -m without TEST paths ------------------------------
+
+    def test_pattern_only_discovers_and_filters(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Using only -m (no TEST paths) discovers all tests and filters them
+        by the pattern.
+
+        The project has create.tql in both ctx/ and other/, plus delete.tql
+        in ctx/.  Pattern ``*create*`` should collect the two create files
+        (queue_size == 2).
+        """
+        info = self._setup_project(tmp_path)
+        try:
+            result = run.run_cli(
+                **_run_cli_kwargs(
+                    info["root"],
+                    tests=[],
+                    match_patterns=("*create*",),
+                )
+            )
+            # Both create.tql files should be collected; delete.tql excluded.
+            assert result.queue_size == 2
+            assert result.summary.total == 2
+        finally:
+            self._teardown(info)
+
+    def test_pattern_only_no_match_reports_empty(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """When -m is used without TEST paths and no tests match, the user
+        sees the appropriate message without intersection context."""
+        info = self._setup_project(tmp_path)
+        try:
+            result = run.run_cli(
+                **_run_cli_kwargs(
+                    info["root"],
+                    tests=[],
+                    match_patterns=("*nonexistent*",),
+                )
+            )
+            assert result.queue_size == 0
+            output = capsys.readouterr().out
+            assert "no tests matched pattern(s):" in output
+            assert "'*nonexistent*'" in output
+            assert "within the selected paths" not in output
+        finally:
+            self._teardown(info)
+
+    # -- multiple projects: match patterns with all_projects ---------------
+
+    def test_match_patterns_across_multiple_projects(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """When --all-projects is used with -m patterns, pattern filtering is
+        applied independently to each project.
+
+        Sets up a root project (with ctx/create.tql, ctx/delete.tql,
+        other/create.tql) and a satellite project (with create.tql and
+        list.tql).  Pattern ``*create*`` should collect the two create files
+        from the root AND the one create file from the satellite (total 3).
+        """
+        info = self._setup_project(tmp_path)
+        root = info["root"]
+
+        # Create a satellite project inside the root project directory.
+        satellite = _make_satellite_project(root, "satellite", ["create", "list"])
+        monkeypatch.chdir(root)
+
+        try:
+            result = run.run_cli(
+                **_run_cli_kwargs(
+                    root,
+                    tests=[Path("satellite")],
+                    match_patterns=("*create*",),
+                    all_projects=True,
+                )
+            )
+            # Root project: ctx/create.tql + other/create.tql = 2 matches.
+            # Satellite:    tests/create.tql = 1 match.
+            # Total across both projects: 3.
+            assert result.queue_size == 3
+            assert result.summary.total == 3
+        finally:
+            self._teardown(info)
+
+    def test_match_patterns_multiple_projects_no_cross_interference(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A pattern that matches tests only in one project does not produce
+        false positives or suppress results in the other project.
+
+        The satellite has a unique test ``deploy.tql`` that does not exist in
+        the root project.  Pattern ``*deploy*`` should collect only that single
+        test from the satellite while the root contributes zero matches.
+        """
+        info = self._setup_project(tmp_path)
+        root = info["root"]
+
+        satellite = _make_satellite_project(root, "satellite", ["deploy", "list"])
+        monkeypatch.chdir(root)
+
+        try:
+            result = run.run_cli(
+                **_run_cli_kwargs(
+                    root,
+                    tests=[Path("satellite")],
+                    match_patterns=("*deploy*",),
+                    all_projects=True,
+                )
+            )
+            # Root project has no "deploy" test -> 0 matches.
+            # Satellite has tests/deploy.tql -> 1 match.
+            assert result.queue_size == 1
+            assert result.summary.total == 1
+        finally:
+            self._teardown(info)


### PR DESCRIPTION
## Summary

- Add `-m`/`--match` CLI option that selects tests by fnmatch glob patterns matched against relative test paths
- Multiple patterns act as OR; when combined with positional TEST paths, only tests matching both are run (intersection)
- Suite expansion ensures partial suite matches include the full suite for consistent lifecycle

## Examples

```sh
tenzir-test -m '*context*'                  # Run all tests matching "context"
tenzir-test -m '*create*' -m '*update*'     # Run tests matching either pattern
tenzir-test tests/context/ -m '*create*'    # Filter a directory by pattern
```

## Test plan

- [x] All 194 existing tests pass
- [x] New unit tests for `_filter_paths_by_patterns()` (basic matching, OR semantics, no match, empty patterns, case sensitivity)
- [x] New unit tests for `_expand_suites()` (partial suite expansion, standalone tests unchanged)
- [x] CLI passthrough tests for `-m` flag, multiple flags, and combination with path args
- [x] Manual verification with `tenzir-test --root example-project -m '*context*'` (4 tests matched)
- [x] Help text verified via `tenzir-test -h`
- [x] Documentation updated in reference, guides/testing, and guides/packages

## Documentation PR

- tenzir/docs#194

🤖 Generated with [Claude Code](https://claude.com/claude-code)