### PR TITLE
Add FixtureUnavailable exception for opt-in fixture skip handling

### DIFF
--- a/example-project/README.md
+++ b/example-project/README.md
@@ -20,6 +20,7 @@ pieces fit together.
 example-project/
 ├── fixtures/
 │   ├── __init__.py
+│   ├── container.py
 │   ├── http.py
 │   └── server.py
 ├── inputs/
@@ -27,6 +28,9 @@ example-project/
 ├── runners/
 │   └── __init__.py
 └── tests/
+    ├── container/
+    │   ├── test.yaml
+    │   └── check.{sh,txt}
     ├── context/
     │   ├── test.yaml
     │   ├── 01-context-create.{tql,txt}
@@ -82,6 +86,11 @@ example-project/
   frontmatter can request fixtures directly from shell scripts.
 - **Skip demo** (`tests/lazy.tql`): uses `skip:` frontmatter to illustrate how
   the harness reports intentionally skipped tests along with custom messages.
+- **Fixture unavailability** (`tests/container`): the `container` fixture
+  raises `FixtureUnavailable` because it checks for a binary that does not
+  exist. The suite's `test.yaml` opts into graceful skipping via
+  `skip: {on: fixture-unavailable}`, so the test is reported as skipped rather
+  than failing the run.
 - **Satellite demo** (`../example-satellite/`): a self-contained project that
   reuses the root fixtures **and** the `xxd` runner while adding its own
   `satellite_marker` fixture. Invoke `uvx tenzir-test --root example-project

--- a/example-project/fixtures/__init__.py
+++ b/example-project/fixtures/__init__.py
@@ -3,6 +3,6 @@
 from __future__ import annotations
 
 # Import submodules so their @fixture decorators run at import time.
-from . import http, server  # noqa: F401
+from . import container, http, server  # noqa: F401
 
-__all__ = ["http", "server"]
+__all__ = ["container", "http", "server"]

--- a/example-project/fixtures/container.py
+++ b/example-project/fixtures/container.py
@@ -16,7 +16,7 @@ from tenzir_test.fixtures import FixtureUnavailable, fixture
 
 @fixture()
 def container() -> Iterator[dict[str, str]]:
-    binary = shutil.which("container-runtime-example")
-    if binary is None:
+    runtime_path = shutil.which("container-runtime-example")
+    if runtime_path is None:
         raise FixtureUnavailable("container-runtime-example not found")
-    yield {"CONTAINER_RUNTIME": binary}
+    yield {"CONTAINER_RUNTIME": runtime_path}

--- a/example-project/fixtures/container.py
+++ b/example-project/fixtures/container.py
@@ -1,0 +1,22 @@
+"""Fixture that demonstrates FixtureUnavailable.
+
+This fixture checks for a ``container-runtime-example`` binary that does not
+exist, causing it to raise ``FixtureUnavailable`` on every run. Tests that
+depend on this fixture and opt in via ``skip: {on: fixture-unavailable}`` are
+gracefully skipped instead of failing.
+"""
+
+from __future__ import annotations
+
+import shutil
+from typing import Iterator
+
+from tenzir_test.fixtures import FixtureUnavailable, fixture
+
+
+@fixture()
+def container() -> Iterator[dict[str, str]]:
+    binary = shutil.which("container-runtime-example")
+    if binary is None:
+        raise FixtureUnavailable("container-runtime-example not found")
+    yield {"CONTAINER_RUNTIME": binary}

--- a/example-project/tests/container/check.sh
+++ b/example-project/tests/container/check.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -eu
+
+echo "container runtime: ${CONTAINER_RUNTIME}"

--- a/example-project/tests/container/check.txt
+++ b/example-project/tests/container/check.txt
@@ -1,0 +1,1 @@
+container runtime: container-runtime-example

--- a/example-project/tests/container/test.yaml
+++ b/example-project/tests/container/test.yaml
@@ -1,0 +1,4 @@
+suite: container-demo
+fixtures: [container]
+skip:
+  on: fixture-unavailable

--- a/src/tenzir_test/fixtures/__init__.py
+++ b/src/tenzir_test/fixtures/__init__.py
@@ -362,6 +362,28 @@ class FixtureHandle:
     hooks: Mapping[str, Callable[..., Any]] | None = None
 
 
+class FixtureUnavailable(Exception):
+    """Raised by a fixture when it cannot provide its service.
+
+    When a fixture raises this during initialization (before yielding)
+    and the suite has ``skip: {on: fixture-unavailable}`` in its
+    ``test.yaml``, all tests in the suite are marked as skipped.
+
+    Without the opt-in config, the exception propagates normally and
+    causes a test failure.
+
+    Example::
+
+        @fixture()
+        def my_fixture() -> Iterator[dict[str, str]]:
+            if not shutil.which("docker"):
+                raise FixtureUnavailable(
+                    "container runtime (docker) required but not found"
+                )
+            # ... normal setup ...
+    """
+
+
 class _FactoryCallable(Protocol):
     def __call__(
         self,
@@ -586,28 +608,6 @@ def suite_scope(names: Iterable[str]) -> Iterator[dict[str, str]]:
     finally:
         _SUITE_SCOPE.reset(token)
         stack.close()
-
-
-class FixtureUnavailable(Exception):
-    """Raised by a fixture when it cannot provide its service.
-
-    When a fixture raises this during initialization (before yielding)
-    and the suite has ``skip: {on: fixture-unavailable}`` in its
-    ``test.yaml``, all tests in the suite are marked as skipped.
-
-    Without the opt-in config, the exception propagates normally and
-    causes a test failure.
-
-    Example::
-
-        @fixture()
-        def my_fixture() -> Iterator[dict[str, str]]:
-            if not shutil.which("docker"):
-                raise FixtureUnavailable(
-                    "container runtime (docker) required but not found"
-                )
-            # ... normal setup ...
-    """
 
 
 # Import built-in fixtures so they self-register on package import.

--- a/src/tenzir_test/fixtures/__init__.py
+++ b/src/tenzir_test/fixtures/__init__.py
@@ -588,6 +588,28 @@ def suite_scope(names: Iterable[str]) -> Iterator[dict[str, str]]:
         stack.close()
 
 
+class FixtureUnavailable(Exception):
+    """Raised by a fixture when it cannot provide its service.
+
+    When a fixture raises this during initialization (before yielding)
+    and the suite has ``skip: {on: fixture-unavailable}`` in its
+    ``test.yaml``, all tests in the suite are marked as skipped.
+
+    Without the opt-in config, the exception propagates normally and
+    causes a test failure.
+
+    Example::
+
+        @fixture()
+        def my_fixture() -> Iterator[dict[str, str]]:
+            if not shutil.which("docker"):
+                raise FixtureUnavailable(
+                    "container runtime (docker) required but not found"
+                )
+            # ... normal setup ...
+    """
+
+
 # Import built-in fixtures so they self-register on package import.
 from . import node  # noqa: F401,E402
 
@@ -599,6 +621,7 @@ __all__ = [
     "FixtureSelection",
     "FixturesAccessor",
     "FixtureController",
+    "FixtureUnavailable",
     "activate",
     "acquire_fixture",
     "fixture",

--- a/src/tenzir_test/run.py
+++ b/src/tenzir_test/run.py
@@ -47,6 +47,139 @@ from .runners import (
 
 TestConfig = dict[str, object]
 
+#: YAML value for the ``skip.on`` key that opts in to skipping a suite
+#: when a fixture raises :class:`FixtureUnavailable`.
+SKIP_ON_FIXTURE_UNAVAILABLE: typing.Final[str] = "fixture-unavailable"
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class SkipConfig:
+    """Typed wrapper for the ``skip`` test configuration value.
+
+    Replaces the raw ``str | dict | None`` representation with an explicit
+    type so that consumers never need to perform ``isinstance`` checks
+    themselves.
+
+    Two forms are supported:
+
+    * **Static skip** -- the test is unconditionally skipped with a reason
+      string (``skip: "reason"`` in YAML).
+    * **Conditional skip** -- the test is skipped only when a fixture
+      raises ``FixtureUnavailable`` (``skip: {on: fixture-unavailable}``
+      in YAML, directory-level only).
+    """
+
+    reason: str | None = None
+    on_fixture_unavailable: bool = False
+
+    # -- query helpers -------------------------------------------------------
+
+    @property
+    def is_static(self) -> bool:
+        """Return ``True`` when the test should be unconditionally skipped."""
+        return self.reason is not None and not self.on_fixture_unavailable
+
+    @property
+    def is_conditional(self) -> bool:
+        """Return ``True`` when this is a fixture-unavailable guard."""
+        return self.on_fixture_unavailable
+
+    # -- factory -------------------------------------------------------------
+
+    _VALID_DICT_KEYS: typing.ClassVar[frozenset[str]] = frozenset({"on", "reason"})
+    _VALID_ON_VALUES: typing.ClassVar[frozenset[str]] = frozenset({SKIP_ON_FIXTURE_UNAVAILABLE})
+
+    # PyYAML (YAML 1.1) parses bare ``on`` as the boolean ``True``.
+    # Map such keys back to the intended string form before validation.
+    _YAML_BOOL_KEY_MAP: typing.ClassVar[dict[object, str]] = {True: "on", False: "off"}
+
+    @classmethod
+    def _normalize_dict_keys(cls, raw: dict[object, object]) -> dict[str, object]:
+        """Return a copy with YAML boolean keys replaced by their string equivalents."""
+        out: dict[str, object] = {}
+        for k, v in raw.items():
+            if isinstance(k, bool):
+                normalized = cls._YAML_BOOL_KEY_MAP.get(k)
+                if normalized is None:
+                    normalized = str(k).lower()
+                out[normalized] = v
+            else:
+                out[str(k)] = v
+        return out
+
+    @classmethod
+    def from_raw(
+        cls,
+        value: object,
+        *,
+        origin: Literal["directory", "test"],
+        location: "Path | str",
+        line_number: int | None = None,
+    ) -> "SkipConfig | None":
+        """Parse a raw YAML value into a ``SkipConfig``.
+
+        Returns ``None`` when *value* is ``None`` (skip not configured).
+        Raises ``ValueError`` via ``_raise_config_error`` on invalid input.
+        """
+        if value is None:
+            return None
+
+        if isinstance(value, str):
+            if not value.strip():
+                _raise_config_error(
+                    location,
+                    "'skip' string value must be non-empty",
+                    line_number,
+                )
+            return cls(reason=value)
+
+        if isinstance(value, dict):
+            if origin != "directory":
+                _raise_config_error(
+                    location,
+                    f"'skip' mapping form (e.g. {{on: {SKIP_ON_FIXTURE_UNAVAILABLE}}}) "
+                    "is only valid in directory-level test.yaml files, "
+                    "not in test frontmatter",
+                    line_number,
+                )
+            normalized = cls._normalize_dict_keys(value)
+            unknown_keys = set(normalized.keys()) - cls._VALID_DICT_KEYS
+            if unknown_keys:
+                _raise_config_error(
+                    location,
+                    f"'skip' mapping contains unknown keys: "
+                    f"{', '.join(sorted(unknown_keys))}; "
+                    f"allowed keys are: {', '.join(sorted(cls._VALID_DICT_KEYS))}",
+                    line_number,
+                )
+            on_value = normalized.get("on")
+            if on_value not in cls._VALID_ON_VALUES:
+                _raise_config_error(
+                    location,
+                    f"'skip.on' must be one of "
+                    f"{', '.join(repr(v) for v in sorted(cls._VALID_ON_VALUES))}, "
+                    f"got '{on_value}'",
+                    line_number,
+                )
+            reason = normalized.get("reason")
+            if reason is not None and (not isinstance(reason, str) or not reason.strip()):
+                _raise_config_error(
+                    location,
+                    "'skip.reason' must be a non-empty string",
+                    line_number,
+                )
+            return cls(
+                reason=reason if isinstance(reason, str) else None,
+                on_fixture_unavailable=True,
+            )
+
+        _raise_config_error(
+            location,
+            f"'skip' must be a string or mapping {{on: ..., reason: ...}}, "
+            f"got '{type(value).__name__}'",
+            line_number,
+        )
+
 
 @dataclasses.dataclass(frozen=True, slots=True)
 class TestQueueItem:
@@ -313,6 +446,22 @@ def format_failure_message(message: str) -> str:
 
 _apply_color_palette()
 ANSI_ESCAPE = re.compile(r"\x1b\[[0-9;]*m")
+# Broader pattern covering all common ANSI escape sequences (CSI, OSC, etc.).
+_ANSI_ESCAPE_FULL = re.compile(r"\x1b(?:\[[0-9;]*[A-Za-z]|\][^\x07]*\x07|\[[^\x1b]*)")
+# ASCII C0 control characters except tab (0x09) which is benign.
+_CONTROL_CHARS = re.compile(r"[\x00-\x08\x0a-\x1f\x7f]")
+
+
+def _sanitize_message(value: str) -> str:
+    """Remove ANSI escape sequences and control characters from *value*.
+
+    This is used to prevent untrusted exception messages from injecting
+    terminal escape sequences or newlines into log/stdout output.
+    """
+    value = _ANSI_ESCAPE_FULL.sub("", value)
+    value = _CONTROL_CHARS.sub("", value)
+    return value
+
 
 stdout_lock = threading.RLock()
 
@@ -1238,7 +1387,7 @@ def _canonical_config_key(key: str) -> str:
     return key
 
 
-ConfigOrigin = Literal["directory", "frontmatter"]
+ConfigOrigin = Literal["directory", "test"]
 
 
 def _raise_config_error(
@@ -1472,38 +1621,16 @@ def _assign_config_option(
         return
 
     if canonical == "skip":
-        if isinstance(value, str):
-            if not value.strip():
-                _raise_config_error(
-                    location,
-                    "'skip' string value must be non-empty",
-                    line_number,
-                )
-            config[canonical] = value
-            return
-        if isinstance(value, dict):
-            on_value = value.get("on")
-            if on_value != "fixture-unavailable":
-                _raise_config_error(
-                    location,
-                    f"'skip.on' must be 'fixture-unavailable', got '{on_value}'",
-                    line_number,
-                )
-            reason = value.get("reason")
-            if reason is not None and (not isinstance(reason, str) or not reason.strip()):
-                _raise_config_error(
-                    location,
-                    "'skip.reason' must be a non-empty string",
-                    line_number,
-                )
-            config[canonical] = value
-            return
-        _raise_config_error(
-            location,
-            f"'skip' must be a string or mapping {{on: ..., reason: ...}}, "
-            f"got '{type(value).__name__}'",
-            line_number,
+        # Delegate all validation and parsing to SkipConfig.from_raw which
+        # raises ValueError (via _raise_config_error) on invalid input.
+        parsed = SkipConfig.from_raw(
+            value,
+            origin=origin,
+            location=location,
+            line_number=line_number,
         )
+        config[canonical] = parsed
+        return
 
     if canonical == "error":
         if isinstance(value, bool):
@@ -1542,7 +1669,7 @@ def _assign_config_option(
 
     if canonical == "fixtures":
         suite_value = config.get("suite")
-        if origin == "frontmatter" and isinstance(suite_value, str) and suite_value.strip():
+        if origin == "test" and isinstance(suite_value, str) and suite_value.strip():
             _raise_config_error(
                 location,
                 "'fixtures' cannot be specified in test frontmatter within a suite; configure fixtures in test.yaml",
@@ -1570,7 +1697,7 @@ def _assign_config_option(
         )
         return
     if canonical == "retry":
-        if origin == "frontmatter" and isinstance(config.get("suite"), str):
+        if origin == "test" and isinstance(config.get("suite"), str):
             _raise_config_error(
                 location,
                 "'retry' cannot be overridden in test frontmatter within a suite",
@@ -2139,7 +2266,7 @@ def parse_test_config(test_file: Path, coverage: bool = False) -> TestConfig:
                     str(key),
                     value,
                     location=test_file,
-                    origin="frontmatter",
+                    origin="test",
                 )
 
     if not consumed_frontmatter and is_comment_frontmatter:
@@ -2166,7 +2293,7 @@ def parse_test_config(test_file: Path, coverage: bool = False) -> TestConfig:
                 value,
                 location=test_file,
                 line_number=line_number,
-                origin="frontmatter",
+                origin="test",
             )
 
     if coverage:
@@ -3269,6 +3396,36 @@ def run_simple_test(
     return True
 
 
+def _compose_skip_reason(
+    static_reason: str | None,
+    exception_reason: str | None,
+    *,
+    fallback: str = "fixture unavailable",
+) -> str:
+    """Build a human-readable skip reason from up to two sources.
+
+    Handles four cases:
+    - Both a static config reason and an exception message are present: join
+      them with ``": "``.
+    - Only a static config reason is present: use it as-is.
+    - Only an exception message is present: use it as-is.
+    - Neither is present: return the *fallback* string.
+    The *exception_reason* is sanitized to strip ANSI escape sequences
+    and control characters before use.
+    """
+    if exception_reason:
+        exception_reason = _sanitize_message(exception_reason)
+    has_static = bool(static_reason)
+    has_exc = bool(exception_reason)
+    if has_static and has_exc:
+        return f"{static_reason}: {exception_reason}"
+    if has_static:
+        return static_reason  # type: ignore[return-value]
+    if has_exc:
+        return exception_reason  # type: ignore[return-value]
+    return fallback
+
+
 def handle_skip(reason: str, test: Path, update: bool, output_ext: str) -> bool | str:
     if is_verbose_output():
         rel_path = _relativize_path(test)
@@ -3438,28 +3595,24 @@ class Worker:
                     if interrupted:
                         break
         except fixtures_impl.FixtureUnavailable as exc:
-            skip_cfg = primary_config.get("skip")
-            if not (isinstance(skip_cfg, dict) and skip_cfg.get("on") == "fixture-unavailable"):
+            skip_cfg: SkipConfig | None = primary_config.get("skip")  # type: ignore[assignment]
+            if not (isinstance(skip_cfg, SkipConfig) and skip_cfg.is_conditional):
                 raise
-            static_reason = skip_cfg.get("reason")
-            exc_reason = str(exc)
-            if static_reason and exc_reason:
-                reason = f"{static_reason}: {exc_reason}"
-            elif static_reason:
-                reason = static_reason
-            elif exc_reason:
-                reason = exc_reason
-            else:
-                reason = "fixture unavailable"
+            reason = _compose_skip_reason(skip_cfg.reason, str(exc))
             _CLI_LOGGER.warning(
                 "fixture unavailable for suite '%s': %s",
                 suite_item.suite.name,
                 reason,
             )
-            for test_item in tests:
+            for skip_index, test_item in enumerate(tests, start=1):
                 rel_path = _relativize_path(test_item.path)
                 if is_verbose_output():
-                    suite_suffix = _format_suite_suffix()
+                    with _push_suite_context(
+                        name=suite_item.suite.name,
+                        index=skip_index,
+                        total=total,
+                    ):
+                        suite_suffix = _format_suite_suffix()
                     with stdout_lock:
                         print(
                             f"{SKIP} skipped {rel_path}{suite_suffix}: "

--- a/src/tenzir_test/runners/diff_runner.py
+++ b/src/tenzir_test/runners/diff_runner.py
@@ -5,7 +5,10 @@ import os
 import typing
 from pathlib import Path
 
-from tenzir_test import fixtures as fixture_api
+if typing.TYPE_CHECKING:
+    from tenzir_test.run import SkipConfig
+
+from tenzir_test import fixtures as fixture_api  # type: ignore[no-redef]
 
 from ._utils import get_run_module
 from .tql_runner import TqlRunner
@@ -20,17 +23,25 @@ class DiffRunner(TqlRunner):
     def run(self, test: Path, update: bool, coverage: bool = False) -> bool | str:
         run_mod = get_run_module()
         test_config = run_mod.parse_test_config(test, coverage=coverage)
-        skip_value = test_config.get("skip")
-        if isinstance(skip_value, str):
-            return typing.cast(
-                bool | str,
-                run_mod.handle_skip(
-                    skip_value,
-                    test,
-                    update=update,
-                    output_ext=self.output_ext,
-                ),
-            )
+        skip_cfg: SkipConfig | None = test_config.get("skip")
+        if skip_cfg is not None:
+            if skip_cfg.is_static:
+                assert skip_cfg.reason is not None
+                return typing.cast(
+                    bool | str,
+                    run_mod.handle_skip(
+                        skip_cfg.reason,
+                        test,
+                        update=update,
+                        output_ext=self.output_ext,
+                    ),
+                )
+            if skip_cfg.is_conditional:
+                raise ValueError(
+                    f"Conditional 'skip' config (on: fixture-unavailable) "
+                    f"is a suite-level directive and cannot be handled by "
+                    f"individual test runners. Test: {test}"
+                )
 
         inputs_override = typing.cast(str | None, test_config.get("inputs"))
         env, config_args = run_mod.get_test_env_and_config_args(test, inputs=inputs_override)

--- a/src/tenzir_test/runners/tenzir_runner.py
+++ b/src/tenzir_test/runners/tenzir_runner.py
@@ -14,11 +14,12 @@ class TenzirRunner(TqlRunner):
     def run(self, test: Path, update: bool, coverage: bool = False) -> bool | str:
         run_mod = get_run_module()
         test_config = run_mod.parse_test_config(test, coverage=coverage)
-        if test_config.get("skip"):
+        skip_value = test_config.get("skip")
+        if isinstance(skip_value, str):
             return typing.cast(
                 bool | str,
                 run_mod.handle_skip(
-                    str(test_config["skip"]),
+                    skip_value,
                     test,
                     update=update,
                     output_ext=self.output_ext,

--- a/src/tenzir_test/runners/tenzir_runner.py
+++ b/src/tenzir_test/runners/tenzir_runner.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 import typing
 from pathlib import Path
 
+if typing.TYPE_CHECKING:
+    from tenzir_test.run import SkipConfig
+
 from ._utils import get_run_module
 from .tql_runner import TqlRunner
 
@@ -14,17 +17,25 @@ class TenzirRunner(TqlRunner):
     def run(self, test: Path, update: bool, coverage: bool = False) -> bool | str:
         run_mod = get_run_module()
         test_config = run_mod.parse_test_config(test, coverage=coverage)
-        skip_value = test_config.get("skip")
-        if isinstance(skip_value, str):
-            return typing.cast(
-                bool | str,
-                run_mod.handle_skip(
-                    skip_value,
-                    test,
-                    update=update,
-                    output_ext=self.output_ext,
-                ),
-            )
+        skip_cfg: SkipConfig | None = test_config.get("skip")
+        if skip_cfg is not None:
+            if skip_cfg.is_static:
+                assert skip_cfg.reason is not None
+                return typing.cast(
+                    bool | str,
+                    run_mod.handle_skip(
+                        skip_cfg.reason,
+                        test,
+                        update=update,
+                        output_ext=self.output_ext,
+                    ),
+                )
+            if skip_cfg.is_conditional:
+                raise ValueError(
+                    f"Conditional 'skip' config (on: fixture-unavailable) "
+                    f"is a suite-level directive and cannot be handled by "
+                    f"individual test runners. Test: {test}"
+                )
         return bool(
             run_mod.run_simple_test(
                 test,


### PR DESCRIPTION
## Summary

Fixtures can now signal service unavailability (e.g., missing Docker, Podman not installed) by raising a new `FixtureUnavailable` exception. When a suite enables the structured skip config in `test.yaml`, all dependent tests gracefully skip instead of crashing the worker thread.

This is an opt-in feature: without the configuration, `FixtureUnavailable` propagates normally and fails the suite, preventing silent masking of real failures.

## Changes

### Core Implementation

1. **`src/tenzir_test/fixtures/__init__.py`**
   - New `FixtureUnavailable` exception class with comprehensive docstring
   - Exported in `__all__` for public API

2. **`src/tenzir_test/run.py`**
   - Extended skip config validation to accept structured dict form: `{on: fixture-unavailable, reason: "..."}`
   - Added `except FixtureUnavailable` handler in `_run_suite` that marks all suite tests as skipped when opted in
   - Reason messages are composed from static config and exception text

3. **`src/tenzir_test/runners/tenzir_runner.py`**
   - Fixed skip check to use `isinstance(skip_value, str)` instead of truthy check
   - Prevents dict skip configs from triggering unconditional skip behavior

### Example Project

4. **`example-project/fixtures/container.py`** (NEW)
   - Example fixture demonstrating `FixtureUnavailable` pattern
   - Checks for non-existent `container-runtime-example` binary to simulate unavailability

5. **`example-project/tests/container/`** (NEW)
   - `test.yaml` - Suite config with `skip: {on: fixture-unavailable}`
   - `check.sh` - Test using the container fixture
   - `check.txt` - Baseline output

6. **`example-project/fixtures/__init__.py`** (UPDATED)
   - Imported container fixture for auto-registration

7. **`example-project/README.md`** (UPDATED)
   - Updated layout and highlights

### Documentation

8. **`.docs/src/content/docs/reference/test-framework/index.mdx`** (UPDATED)
   - Updated skip config table in Configuration and frontmatter section
   - New "Skip configuration" subsection explaining both string and structured forms
   - New "Fixture unavailability" subsection with API and configuration details

9. **`.docs/src/content/docs/guides/testing/create-fixtures.mdx`** (UPDATED)
   - New "Handle unavailable fixtures" section
   - Shows how to raise `FixtureUnavailable` in fixtures
   - Explains opt-in graceful skipping behavior with `test.yaml` configuration

## Opt-in Behavior

Without structured skip config:
- `FixtureUnavailable` propagates and fails the suite

With structured skip config in `test.yaml`:
```yaml
skip:
  on: fixture-unavailable
  reason: "container runtime required"
```
- Tests in the suite gracefully skip with the provided reason
- Worker thread continues normally

## Example Usage

```python
from tenzir_test.fixtures import fixture, FixtureUnavailable

@fixture()
def my_fixture() -> Iterator[dict[str, str]]:
    if not shutil.which("docker"):
        raise FixtureUnavailable(
            "Docker required but not found"
        )
    # ... normal setup ...
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)