### PR TITLE
Centralize skip-handling logic in engine

### DIFF
--- a/src/tenzir_test/run.py
+++ b/src/tenzir_test/run.py
@@ -3665,6 +3665,23 @@ class Worker:
                 )
             if suite_fixtures is None:
                 configured_fixtures = config_fixtures
+            skip_cfg = cast(SkipConfig | None, config.get("skip"))
+            if skip_cfg is not None and skip_cfg.is_static:
+                assert skip_cfg.reason is not None
+                outcome = handle_skip(
+                    skip_cfg.reason,
+                    test_path,
+                    update=self._update,
+                    output_ext=getattr(runner, "output_ext", "txt"),
+                )
+                summary.total += 1
+                summary.record_runner_outcome(runner.name, "skipped")
+                if fixtures:
+                    summary.record_fixture_outcome(fixtures, "skipped")
+                summary.skipped += 1
+                summary.skipped_paths.append(rel_path)
+                return False
+            # Conditional skips are suite-level — _run_suite handles them.
         if parse_error is not None:
             message = format_failure_message(parse_error)
             report_failure(test_path, message)

--- a/src/tenzir_test/runners/diff_runner.py
+++ b/src/tenzir_test/runners/diff_runner.py
@@ -5,10 +5,7 @@ import os
 import typing
 from pathlib import Path
 
-if typing.TYPE_CHECKING:
-    from tenzir_test.run import SkipConfig
-
-from tenzir_test import fixtures as fixture_api  # type: ignore[no-redef]
+from tenzir_test import fixtures as fixture_api
 
 from ._utils import get_run_module
 from .tql_runner import TqlRunner
@@ -23,25 +20,6 @@ class DiffRunner(TqlRunner):
     def run(self, test: Path, update: bool, coverage: bool = False) -> bool | str:
         run_mod = get_run_module()
         test_config = run_mod.parse_test_config(test, coverage=coverage)
-        skip_cfg: SkipConfig | None = test_config.get("skip")
-        if skip_cfg is not None:
-            if skip_cfg.is_static:
-                assert skip_cfg.reason is not None
-                return typing.cast(
-                    bool | str,
-                    run_mod.handle_skip(
-                        skip_cfg.reason,
-                        test,
-                        update=update,
-                        output_ext=self.output_ext,
-                    ),
-                )
-            if skip_cfg.is_conditional:
-                raise ValueError(
-                    f"Conditional 'skip' config (on: fixture-unavailable) "
-                    f"is a suite-level directive and cannot be handled by "
-                    f"individual test runners. Test: {test}"
-                )
 
         inputs_override = typing.cast(str | None, test_config.get("inputs"))
         env, config_args = run_mod.get_test_env_and_config_args(test, inputs=inputs_override)

--- a/src/tenzir_test/runners/tenzir_runner.py
+++ b/src/tenzir_test/runners/tenzir_runner.py
@@ -1,10 +1,6 @@
 from __future__ import annotations
 
-import typing
 from pathlib import Path
-
-if typing.TYPE_CHECKING:
-    from tenzir_test.run import SkipConfig
 
 from ._utils import get_run_module
 from .tql_runner import TqlRunner
@@ -16,26 +12,6 @@ class TenzirRunner(TqlRunner):
 
     def run(self, test: Path, update: bool, coverage: bool = False) -> bool | str:
         run_mod = get_run_module()
-        test_config = run_mod.parse_test_config(test, coverage=coverage)
-        skip_cfg: SkipConfig | None = test_config.get("skip")
-        if skip_cfg is not None:
-            if skip_cfg.is_static:
-                assert skip_cfg.reason is not None
-                return typing.cast(
-                    bool | str,
-                    run_mod.handle_skip(
-                        skip_cfg.reason,
-                        test,
-                        update=update,
-                        output_ext=self.output_ext,
-                    ),
-                )
-            if skip_cfg.is_conditional:
-                raise ValueError(
-                    f"Conditional 'skip' config (on: fixture-unavailable) "
-                    f"is a suite-level directive and cannot be handled by "
-                    f"individual test runners. Test: {test}"
-                )
         return bool(
             run_mod.run_simple_test(
                 test,


### PR DESCRIPTION
## Summary

Move static-skip handling out of individual runners (`TenzirRunner` and `DiffRunner`) into the engine's `_run_test_item` method. This refactoring centralizes skip logic at the engine level where summary tracking occurs, ensuring skipped tests are properly recorded with correct outcome metrics.

## Changes

- **src/tenzir_test/run.py** — Added static-skip handling in `_run_test_item` after config parsing but before dispatching to runners. Static skips are now handled at the engine level with proper summary tracking.
- **src/tenzir_test/runners/tenzir_runner.py** — Removed all skip-handling logic (parse_test_config call, SkipConfig import, typing import, and skip block). Runner now only executes the test.
- **src/tenzir_test/runners/diff_runner.py** — Removed skip-handling block and TYPE_CHECKING import for SkipConfig. Kept parse_test_config call since DiffRunner still needs it for inputs, fixtures, and timeout.

## Rationale

By handling skips at the engine level rather than in individual runners, we achieve:
- Centralized skip logic that's easier to maintain
- Proper summary tracking and reporting in one place
- Cleaner separation of concerns—runners handle test execution only
- Consistent skip handling across all runner types

Generated with Claude Code