### PR TITLE
Add substring matching as default for -m/--match patterns

### DIFF
--- a/src/tenzir_test/cli.py
+++ b/src/tenzir_test/cli.py
@@ -164,9 +164,10 @@ Documentation: https://docs.tenzir.com/reference/test-framework/
     multiple=True,
     type=str,
     help=(
-        "Run tests whose relative path matches a glob pattern (fnmatch syntax). "
-        "Useful for selecting tests by name across different directories. "
-        "Repeatable; tests matching any pattern are selected. "
+        "Run tests whose relative path matches a substring or glob pattern. "
+        "Bare strings match as substrings (e.g. 'mysql' matches any path "
+        "containing 'mysql'). Glob metacharacters (*, ?, [) trigger fnmatch "
+        "mode. Repeatable; tests matching any pattern are selected. "
         "If TEST paths are also given, only tests matching both the path and "
         "pattern are run (intersection). "
         "Note: if a matched test belongs to a suite (configured via test.yaml), "
@@ -208,8 +209,9 @@ def cli(
       - Directories to run all tests within (e.g., tests/alerts/)
       - Omitted to run all discovered tests in the project
 
-    Use -m/--match to select tests by glob pattern (fnmatch syntax).
-    Patterns match against relative paths shown in test output.
+    Use -m/--match to select tests by substring or glob pattern.
+    Bare strings match as substrings; glob metacharacters (*, ?, [) trigger
+    fnmatch mode. Patterns match against relative paths shown in test output.
     When both TEST paths and -m patterns are given, only tests matching both
     are run (intersection). Empty pattern strings are silently ignored.
     If a matched test belongs to a suite (configured via test.yaml), all


### PR DESCRIPTION
## Summary

Make `-m`/`--match` default to intuitive substring matching instead of requiring full glob syntax. Bare strings without glob metacharacters (`*`, `?`, `[`) are now automatically treated as substring matches by wrapping them in `*…*`. Existing glob patterns behave identically, making this fully backwards-compatible.

## Changes

- **`src/tenzir_test/run.py`**: Added `_FNMATCH_META` constant and `_normalize_pattern()` helper that auto-wraps bare strings in `*…*` for substring matching. Applied it in `_filter_paths_by_patterns` before calling `fnmatch.fnmatchcase`. Updated docstrings to document the new behavior.

- **`src/tenzir_test/cli.py`**: Updated the `-m`/`--match` help text and the `cli()` docstring to explain that bare strings match as substrings while metacharacters trigger fnmatch mode.

- **`tests/test_run.py`**: Added 3 new tests to `TestFilterPathsByPatterns`:
  - `test_bare_substring_match`: Verifies bare strings match substrings
  - `test_bare_substring_case_sensitive`: Confirms substring matching is case-sensitive
  - `test_glob_metacharacters_not_double_wrapped`: Ensures patterns with `*`, `?`, `[` are not double-wrapped

## Test Plan

- All existing tests pass
- New tests verify substring matching behavior
- Manual testing: `tenzir-test -m 'mysql'` now matches any path containing 'mysql' without requiring full glob syntax
- Backwards-compatible: existing glob patterns like `-m '*mysql*'` or `-m 'tests/mysql/*.tql'` continue to work identically

## Documentation PR

- https://github.com/tenzir/docs/pull/196

Generated with Claude Code