### PR TITLE
Support nested dataclass options in fixtures

### DIFF
--- a/changelog/unreleased/nested-dataclass-options-for-fixtures.md
+++ b/changelog/unreleased/nested-dataclass-options-for-fixtures.md
@@ -1,0 +1,23 @@
+---
+title: Nested dataclass options for fixtures
+type: feature
+authors:
+  - mavam
+  - claude
+pr: 18
+created: 2026-02-11T20:09:40.154206Z
+---
+
+Fixture options now support nested dataclass hierarchies, allowing you to structure complex configurations with multiple levels of organization.
+
+Previously, fixture options were limited to flat fields. Now you can declare nested dataclasses as field types, and tests can pass deeply structured options through frontmatter:
+
+```yaml
+fixtures:
+  - node:
+      server:
+        message:
+          greeting: world
+```
+
+Type safety is preserved across all nesting levels. Optional nested fields (declared with `Optional[T]` or `T | None`) are supported, and omitted nested records use their default values. The example server fixture demonstrates this capability with a `message.greeting` field that flows through to environment variables.

--- a/example-project/README.md
+++ b/example-project/README.md
@@ -84,6 +84,9 @@ example-project/
   calls.
 - **Shell scenarios** (`tests/shell/http-fixture-check.sh`): show how inline
   frontmatter can request fixtures directly from shell scripts.
+- **Nested fixture options** (`tests/shell/server-fixture-options.sh`): shows a
+  nested frontmatter record (`server.message.greeting`) flowing into fixture
+  options and exported as `SERVER_GREETING`.
 - **Skip demo** (`tests/lazy.tql`): uses `skip:` frontmatter to illustrate how
   the harness reports intentionally skipped tests along with custom messages.
 - **Fixture unavailability** (`tests/container`): the `container` fixture

--- a/example-project/fixtures/README.md
+++ b/example-project/fixtures/README.md
@@ -28,9 +28,12 @@ The `server` fixture spawns a controllable subprocess and exposes hooks:
 
 - Python-mode tests simply `import fixtures` and use `acquire_fixture("server")`
   to obtain a controller without declaring the fixture in frontmatter.
+- Declarative tests can pass nested options, for example:
+  `fixtures: [{server: {message: {greeting: world}}}]`.
 - `start()` launches the subprocess, `stop()` tears it down, and optional hooks
   such as `kill()` surface on the controller object.
-- The fixture yields a `SERVER_PID` environment variable for diagnostics.
+- The fixture yields `SERVER_PID` and `SERVER_GREETING` environment variables
+  for diagnostics.
 - Teardown still executes even if tests forget to stop the controller manually.
 
 ```python

--- a/example-project/fixtures/server.py
+++ b/example-project/fixtures/server.py
@@ -3,16 +3,23 @@
 import signal
 import subprocess
 import sys
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from tenzir_test import FixtureHandle, current_options, fixture
+
+
+@dataclass(frozen=True)
+class ServerGreetingOptions:
+    """Nested greeting configuration for the server fixture."""
+
+    greeting: str = "hello"
 
 
 @dataclass(frozen=True)
 class ServerOptions:
     """Optional configuration for the server fixture."""
 
-    greeting: str = "hello"
+    message: ServerGreetingOptions = field(default_factory=ServerGreetingOptions)
 
 
 def _spawn() -> subprocess.Popen:
@@ -27,7 +34,7 @@ def server() -> FixtureHandle:
     # tests, which use acquire_fixture() to call the hooks.
     opts = current_options("server")
     process = _spawn()
-    env = {"SERVER_PID": str(process.pid), "SERVER_GREETING": opts.greeting}
+    env = {"SERVER_PID": str(process.pid), "SERVER_GREETING": opts.message.greeting}
 
     def _teardown() -> None:
         if process.poll() is None:

--- a/example-project/tests/shell/server-fixture-options.sh
+++ b/example-project/tests/shell/server-fixture-options.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
-# fixtures: [{server: {greeting: world}}]
+# fixtures: [{server: {message: {greeting: world}}}]
 
 echo "${SERVER_GREETING}"

--- a/src/tenzir_test/run.py
+++ b/src/tenzir_test/run.py
@@ -1478,7 +1478,7 @@ def _build_fixture_options(
 
     For every spec:
     - If the fixture has a registered options class: construct a typed instance
-      via ``options_cls(**spec.options)`` (or ``options_cls()`` for bare names).
+      with recursive nested dataclass instantiation.
     - If no options class but options were provided: store the raw dict.
     - If no options class and no options: omit from the dict.
     """
@@ -1487,7 +1487,7 @@ def _build_fixture_options(
         options_cls = fixtures_impl.get_options_class(spec.name)
         if options_cls is not None:
             try:
-                result[spec.name] = options_cls(**spec.options) if spec.options else options_cls()
+                result[spec.name] = fixtures_impl._instantiate_options(options_cls, spec.options)
             except TypeError as exc:
                 raise ValueError(f"invalid options for fixture '{spec.name}': {exc}") from exc
         elif spec.options:


### PR DESCRIPTION
## Summary

Fixtures can now receive deeply structured configurations through recursively instantiated nested dataclasses. This enhancement enables rich, hierarchical fixture options while maintaining full type safety.

The framework recursively traverses dataclass option types and instantiates nested dataclasses from mapping data, supporting arbitrarily deep nesting and Optional fields with both `typing.Optional[T]` and `T | None` syntax.

## Changes

- Added `_unwrap_optional()` helper to extract inner types from Optional annotations
- Added `_instantiate_options()` function for recursive dataclass instantiation
- Updated `_build_fixture_options_for_context()` to use the new recursive instantiation
- Comprehensive test coverage for 2-level, 3-level, and optional nested dataclass options
- Example server fixture refactored with nested `ServerGreetingOptions` structure
- Documentation updates demonstrating the new capability

## Test plan

- All existing tests pass
- New tests cover nested dataclass instantiation at multiple nesting levels
- Optional nested fields tested with both `typing.Optional[T]` and `T | None` syntax
- Example test in `example-project/tests/shell/server-fixture-options.sh` demonstrates nested options via frontmatter

## Documentation PR

- tenzir/docs#201

🤖 Generated with [Claude Code](https://claude.com/claude-code)