### PR TITLE
Improve config override log readability

### DIFF
--- a/changelog/unreleased/improved-config-override-log-readability.md
+++ b/changelog/unreleased/improved-config-override-log-readability.md
@@ -1,0 +1,11 @@
+---
+title: Improved config override log readability
+type: bugfix
+authors:
+  - mavam
+  - claude
+pr: 19
+created: 2026-02-13T09:23:52.071478Z
+---
+
+Configuration override log messages now use relative paths and human-friendly formatting instead of absolute paths and raw Python repr output, making debug output easier to read.

--- a/src/tenzir_test/run.py
+++ b/src/tenzir_test/run.py
@@ -919,14 +919,6 @@ _DEFAULT_RUNNER_BY_SUFFIX: dict[str, str] = {
 }
 
 _CONFIG_FILE_NAME = "test.yaml"
-_CONFIG_LOGGER = logging.getLogger("tenzir_test.config")
-_CONFIG_LOGGER.setLevel(logging.INFO)
-if not _CONFIG_LOGGER.handlers:
-    handler = logging.StreamHandler()
-    handler.setLevel(logging.INFO)
-    handler.setFormatter(logging.Formatter("%(message)s"))
-    _CONFIG_LOGGER.addHandler(handler)
-    _CONFIG_LOGGER.propagate = False
 
 
 class _CliDebugHandler(logging.Handler):
@@ -1788,7 +1780,7 @@ def _assign_config_option(
             )
         runner_names = _runner_names or {runner.name for runner in runners_iter_runners()}
         if runner_names and value not in runner_names:
-            _CONFIG_LOGGER.info(
+            _CLI_LOGGER.debug(
                 "Runner '%s' is not registered; proceeding with explicit selection.",
                 value,
             )
@@ -1809,7 +1801,7 @@ def _log_directory_override(
     message = (
         f"{path} overrides '{key}' from {previous!r} (defined in {previous_source}) to {new!r}"
     )
-    _CONFIG_LOGGER.info(message)
+    _CLI_LOGGER.debug(message)
 
 
 def _load_directory_config(directory: Path) -> _DirectoryConfig:

--- a/src/tenzir_test/run.py
+++ b/src/tenzir_test/run.py
@@ -1790,6 +1790,12 @@ def _assign_config_option(
     config[canonical] = value
 
 
+def _format_config_value(value: object) -> str:
+    if isinstance(value, tuple):
+        return "[" + ", ".join(str(v) for v in value) + "]"
+    return repr(value)
+
+
 def _log_directory_override(
     *,
     path: Path,
@@ -1799,7 +1805,9 @@ def _log_directory_override(
     previous_source: Path,
 ) -> None:
     message = (
-        f"{path} overrides '{key}' from {previous!r} (defined in {previous_source}) to {new!r}"
+        f"{_relativize_path(path)} overrides '{key}'"
+        f" from {_format_config_value(previous)} (defined in {_relativize_path(previous_source)})"
+        f" to {_format_config_value(new)}"
     )
     _CLI_LOGGER.debug(message)
 


### PR DESCRIPTION
## Summary

Improves debug log messages from `_log_directory_override` by formatting them more clearly:

- Add `_format_config_value` helper that formats tuples using `str()` (which leverages `FixtureSpec.__str__`) instead of `repr()`, wrapping them in brackets
- Use `_relativize_path()` for both `path` and `previous_source` to show relative paths instead of absolute ones

## Example

**Before:**
```
/Users/mavam/code/tenzir/.../from_mysql/live_signed_stream_insert/test.yaml overrides 'fixtures' from (FixtureSpec(name='mysql', options={}),) (defined in /Users/mavam/code/tenzir/.../from_mysql/test.yaml) to (FixtureSpec(name='mysql', options={'tls': False, 'streaming': 'signed'}),)
```

**After:**
```
tests/operators/from_mysql/live_signed_stream_insert/test.yaml overrides 'fixtures' from [mysql] (defined in tests/operators/from_mysql/test.yaml) to [mysql(streaming='signed', tls=False)]
```

## Test plan

- All 260 tests pass

🤖 Generated with Claude Code