### PR TITLE
Add standalone fixture mode with --fixture CLI option

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,20 @@ for an end-to-end walkthrough of writing tests.
 We also provide a dense [reference](https://docs.tenzir.com/reference/test) that
 explains concepts, configuration, multi-project execution, and CLI details.
 
+## 🧱 Standalone Fixtures
+
+Use `--fixture` to start fixtures without running tests. The harness prints
+fixture-provided `KEY=VALUE` entries and keeps services running until
+interrupted:
+
+```sh
+uvx tenzir-test --fixture mysql
+uvx tenzir-test --fixture 'kafka: {port: 9092}' --debug
+```
+
+`--fixture` is repeatable and runs fixtures in the foreground. Stop with
+`Ctrl+C` for clean teardown.
+
 ## 🗞️ Releases
 
 New versions are published to PyPI through trusted publishing when a GitHub

--- a/changelog/unreleased/standalone-fixture-mode-with-fixture-cli-option.md
+++ b/changelog/unreleased/standalone-fixture-mode-with-fixture-cli-option.md
@@ -1,0 +1,20 @@
+---
+title: Standalone fixture mode with --fixture CLI option
+type: feature
+authors:
+  - mavam
+  - claude
+pr: 20
+created: 2026-02-14T15:30:18.036656Z
+---
+
+You can now start fixtures in foreground mode without running any tests by using the `--fixture` option. This lets you provision services (like a database or message broker) and use them in your workflow.
+
+Specify fixture names or YAML-style configuration:
+
+```sh
+uvx tenzir-test --fixture mysql
+uvx tenzir-test --fixture 'kafka: {port: 9092}' --debug
+```
+
+The harness prints fixture-provided environment variables like `HOST`, `PORT`, and `DATABASE`, then keeps services running until you press `Ctrl+C`. You can repeat `--fixture` to activate multiple fixtures. The option is mutually exclusive with positional TEST arguments.

--- a/tests/test_fixture_mode.py
+++ b/tests/test_fixture_mode.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tenzir_test import run
+from tenzir_test.fixtures import FixtureSpec
+
+
+def _restore_settings(
+    original_settings: run.Settings | None,
+    original_root: Path,
+) -> None:
+    if original_settings is not None:
+        run.apply_settings(original_settings)
+        return
+    run._settings = None
+    run.TENZIR_BINARY = None
+    run.TENZIR_NODE_BINARY = None
+    run._set_project_root(original_root)
+
+
+def test_normalize_cli_fixture_specs_supports_shorthand_mapping() -> None:
+    specs = run._normalize_cli_fixture_specs(["mysql", "kafka:{port: 9092}"])
+    assert specs == (
+        FixtureSpec(name="mysql"),
+        FixtureSpec(name="kafka", options={"port": 9092}),
+    )
+
+
+def test_run_fixture_mode_cli_prints_env_and_tears_down(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    fixture_file = tmp_path / "fixtures.py"
+    fixture_file.write_text(
+        """\
+from dataclasses import dataclass
+
+from tenzir_test.fixtures import current_options, fixture
+
+
+@dataclass(frozen=True)
+class DemoOptions:
+    port: int = 0
+
+
+@fixture(name="standalone_demo", replace=True, options=DemoOptions)
+def standalone_demo():
+    options = current_options("standalone_demo")
+    yield {"STANDALONE_DEMO_PORT": str(options.port)}
+""",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(run, "_wait_for_fixture_shutdown", lambda: None)
+
+    original_settings = run._settings
+    original_root = run.ROOT
+    try:
+        exit_code = run.run_fixture_mode_cli(
+            root=tmp_path,
+            package_dirs=(),
+            fixtures=("standalone_demo:{port: 9092}",),
+            debug=False,
+            keep_tmp_dirs=False,
+        )
+    finally:
+        _restore_settings(original_settings, original_root)
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    lines = [line for line in captured.out.splitlines() if line]
+    assert "STANDALONE_DEMO_PORT=9092" in lines
+    assert any("press Ctrl+C to stop" in line for line in lines)
+
+
+def test_run_fixture_mode_cli_rejects_unknown_fixture(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(run, "_wait_for_fixture_shutdown", lambda: None)
+
+    original_settings = run._settings
+    original_root = run.ROOT
+    try:
+        with pytest.raises(run.HarnessError, match="is not registered"):
+            run.run_fixture_mode_cli(
+                root=tmp_path,
+                package_dirs=(),
+                fixtures=("unknown_fixture",),
+                debug=False,
+                keep_tmp_dirs=False,
+            )
+    finally:
+        _restore_settings(original_settings, original_root)


### PR DESCRIPTION
## Summary

Introduces a new standalone fixture mode that allows users to activate and manage fixtures in foreground mode without running tests. The `--fixture` option starts fixtures and keeps them running until interrupted with Ctrl+C.

- Fixtures can be specified by name ('mysql') or with YAML-style configuration ('kafka: {port: 9092}')
- The mode prints fixture-provided environment variables for integration with external tools
- Clean teardown is guaranteed through signal handling

## Changes

**CLI & Runtime**
- Add `--fixture` repeatable option with validation (mutually exclusive with test arguments)
- Implement `run_fixture_mode_cli()` to activate fixtures and block until shutdown
- Parse CLI fixture specs supporting shorthand mapping syntax (e.g., 'kafka: {port: 9092}')
- Refactor logging configuration into `_configure_runtime_logging()` for reuse

**Documentation**
- Update README.md with standalone fixture examples and usage guidance

**Tests**
- Add CLI dispatch test to verify fixture mode routing
- Add validation test for mutually exclusive test/fixture arguments
- Add comprehensive fixture mode tests covering spec parsing, environment output, and teardown
- Add unknown fixture rejection test

## Test plan

- [x] Run existing test suite to verify no regressions
- [x] Test fixture mode with simple fixture names
- [x] Test fixture mode with YAML-style configuration
- [x] Verify CLI validation prevents mixing test args with --fixture
- [x] Verify clean shutdown on Ctrl+C
- [x] Verify environment variables are printed in sorted order

## Documentation PR

- tenzir/docs#205

🤖 Generated with Claude Code