### PR TITLE
Add fine-grained run-skipped selectors

### DIFF
--- a/changelog/unreleased/run-skipped-tests-with-run-skipped-flag.md
+++ b/changelog/unreleased/run-skipped-tests-with-run-skipped-flag.md
@@ -1,18 +1,23 @@
 ---
-title: Run skipped tests with --run-skipped flag
+title: Add fine-grained run-skipped selectors
 type: feature
 authors:
   - mavam
   - codex
-pr: 23
+pr:
+  - 23
+  - 24
 created: 2026-02-15T18:47:21.61271Z
 ---
 
-The `--run-skipped` flag bypasses all skip configuration and forces tests to execute. Use this when you want to temporarily run tests that are normally skipped via the `skip` configuration in `test.yaml`:
+`tenzir-test` now supports both coarse and fine-grained controls for running skipped tests.
+
+Use `--run-skipped` as a sledgehammer, or `--run-skipped-reason` with the same matching semantics as `--match` (bare substring or glob):
 
 ```sh
 tenzir-test --run-skipped
-tenzir-test tests/alerts/ --run-skipped
+tenzir-test --run-skipped-reason 'maintenance'
+tenzir-test --run-skipped-reason '*docker*'
 ```
 
-This is useful for investigating skipped tests, re-enabling them in CI, or testing changes that might affect skipped scenarios without modifying the skip configuration.
+If both options are provided, `--run-skipped` takes precedence.

--- a/src/tenzir_test/cli.py
+++ b/src/tenzir_test/cli.py
@@ -41,6 +41,9 @@ Examples:
   tenzir-test -m '*ctx*'               Run tests matching a path pattern
   tenzir-test -m '*add*' -m '*del*'    Run tests matching either pattern
   tenzir-test tests/ctx/ -m '*create*' Intersect directory with pattern
+  tenzir-test --run-skipped            Run all skipped tests unconditionally
+  tenzir-test --run-skipped-reason maintenance
+                                       Run only skipped tests whose reason matches
   tenzir-test -u tests/new.tql         Run test and update its baseline
   tenzir-test -p -k tests/debug/       Debug with output streaming and kept temps
   tenzir-test --fixture mysql          Start fixture(s) in foreground mode
@@ -167,7 +170,19 @@ Documentation: https://docs.tenzir.com/reference/test-framework/
 @click.option(
     "--run-skipped",
     is_flag=True,
-    help="Run tests even when skip config is present.",
+    help="Run all skipped tests unconditionally.",
+)
+@click.option(
+    "--run-skipped-reason",
+    "run_skipped_reasons",
+    multiple=True,
+    type=str,
+    help=(
+        "Run tests skipped for reasons matching a substring or glob pattern. "
+        "Bare strings match as substrings; glob metacharacters (*, ?, [) use fnmatch mode. "
+        "Repeatable; matching any reason pattern selects the skipped test. "
+        "Matches against the final displayed skip reason."
+    ),
 )
 @click.option(
     "-a",
@@ -216,6 +231,7 @@ def cli(
     passthrough: bool,
     verbose: bool,
     run_skipped: bool,
+    run_skipped_reasons: tuple[str, ...],
     all_projects: bool,
 ) -> int:
     """Execute test scenarios and compare output against baselines.
@@ -285,6 +301,7 @@ def cli(
             passthrough=passthrough,
             verbose=verbose,
             run_skipped=run_skipped,
+            run_skipped_reasons=list(run_skipped_reasons),
             jobs_overridden=jobs_overridden,
             all_projects=all_projects,
             match_patterns=list(match_patterns),


### PR DESCRIPTION
## Summary

This PR enhances the `--run-skipped` functionality to support fine-grained filtering with the new `--run-skipped-reason` flag, allowing selective execution of skipped tests based on their skip reasons.

Previously, `--run-skipped` forced execution of all skipped tests unconditionally. This improvement introduces a more flexible approach:

- `--run-skipped`: Execute all skipped tests unconditionally (sledgehammer approach)
- `--run-skipped-reason <pattern>`: Execute only skipped tests whose reason matches the pattern (substring or glob)
- Patterns can be combined, and `--run-skipped` takes precedence when both options are used

## Test plan

- [x] Tests added for new `RunSkippedSelector` model with coarse and fine-grained filtering
- [x] CLI tests verify correct parsing and precedence of both flags
- [x] Worker integration tests confirm both static and conditional skips are handled correctly
- [x] Reason matching uses the same substring/glob semantics as `--match`
- [x] `run_skipped_match_count` tracks matched skips, with diagnostic output when no tests match filters
- [x] Changelog updated with usage examples

See #23 for related prior work on the initial `--run-skipped` implementation.

## Documentation PR

- https://github.com/tenzir/docs/pull/210

🤖 Generated with Claude Code