### PR TITLE
Avoid traceback on fixture unavailable

### DIFF
--- a/changelog/unreleased/clean-error-messages-for-unavailable-fixtures.md
+++ b/changelog/unreleased/clean-error-messages-for-unavailable-fixtures.md
@@ -1,0 +1,11 @@
+---
+title: Clean error messages for unavailable fixtures
+type: bugfix
+authors:
+  - mavam
+  - codex
+pr: 25
+created: 2026-02-16T15:13:24.735004Z
+---
+
+When a fixture becomes unavailable during test execution, the test harness now provides a clean error message instead of a Python traceback.


### PR DESCRIPTION
## Summary

Wraps `FixtureUnavailable` exceptions in a `HarnessError` to provide clean error messages without Python tracebacks. This prevents noisy stack traces when fixtures fail to load and ensures consistent error handling across both fixture mode and worker processes.

The fix extracts error handling logic into a reusable helper function `_raise_fixture_unavailable_harness_error()` and applies it in two places:
- In `run_fixture_mode_cli()` when a fixture setup fails
- In `run_cli()` when a worker process encounters a fixture unavailable error

## Test Plan

- Verifies that `FixtureUnavailable` exceptions are wrapped in `HarnessError` with sanitized messages
- Tests the error handling path when a worker fails with fixture unavailable
- Validates that error messages are preserved and presented cleanly without tracebacks

🤖 Generated with Claude Code