### PR TITLE
Avoid fixture initialization when suite tests are statically skipped

### DIFF
--- a/changelog/unreleased/skip-fixture-initialization-for-suites-with-all-static-skips.md
+++ b/changelog/unreleased/skip-fixture-initialization-for-suites-with-all-static-skips.md
@@ -1,0 +1,11 @@
+---
+title: Skip fixture initialization for suites with all static skips
+type: bugfix
+authors:
+  - mavam
+  - codex
+pr: 26
+created: 2026-02-16T15:24:48.676251Z
+---
+
+The test harness no longer initializes fixtures for suites where all tests are statically skipped. Previously, fixtures were activated even when no tests would run, causing unnecessary startup overhead and potential errors.


### PR DESCRIPTION
## Summary

When every test in a suite is statically skipped and the run-skipped selector
doesn't match, skip fixture activation entirely. This optimization avoids
unnecessary initialization overhead for unavailable fixtures in scenarios
where all tests would be skipped anyway.

## Changes

- Adds `_record_static_skip()` helper to consolidate static skip recording logic
- Adds `_suite_static_skip_plan()` to detect when all suite tests are statically skipped
- Implements early return in `_run_suite()` to skip fixture activation when appropriate
- Replaces inline skip handling in `_run_test_item()` with `_record_static_skip()` call

## Test Coverage

Two new tests verify the optimization:
- `test_worker_suite_static_skip_short_circuits_fixture_activation`: Confirms fixtures are not activated when all tests are skipped
- `test_worker_suite_static_skip_respects_run_skipped_selector`: Confirms fixtures are still activated when run-skipped selector matches

🤖 Generated with Claude Code