### PR TITLE
Ensure .sh files default to shell runner

### DIFF
--- a/changelog/unreleased/shell-test-files-default-to-shell-runner.md
+++ b/changelog/unreleased/shell-test-files-default-to-shell-runner.md
@@ -1,0 +1,11 @@
+---
+title: Shell test files default to shell runner
+type: bugfix
+authors:
+  - mavam
+  - codex
+pr: 30
+created: 2026-02-24T16:32:14.824321Z
+---
+
+Shell test files (`.sh`) now always default to the "shell" runner, even when a directory-level `test.yaml` file specifies a different runner (for example, `runner: tenzir`). This makes shell scripts work reliably in mixed-runner directories without requiring explicit `runner:` frontmatter in each file. Explicit `runner:` declarations in test file frontmatter still take precedence and can override this behavior if needed.

--- a/tests/test_run_config.py
+++ b/tests/test_run_config.py
@@ -502,6 +502,58 @@ def test_parse_python_default_runner(tmp_path: Path, configured_root: Path) -> N
     assert config["retry"] == 1
 
 
+def test_parse_shell_runner_overrides_directory_runner_default(
+    tmp_path: Path, configured_root: Path
+) -> None:
+    suite_dir = tmp_path / "tests" / "mixed"
+    suite_dir.mkdir(parents=True, exist_ok=True)
+    (suite_dir / "test.yaml").write_text("runner: tenzir\n", encoding="utf-8")
+    script = suite_dir / "example.sh"
+    script.write_text("#!/bin/sh\necho ok\n", encoding="utf-8")
+    run._clear_directory_config_cache()
+
+    config = run.parse_test_config(script)
+
+    assert config["runner"] == "shell"
+
+
+def test_parse_shell_runner_frontmatter_overrides_shell_default(
+    tmp_path: Path, configured_root: Path
+) -> None:
+    suite_dir = tmp_path / "tests" / "mixed"
+    suite_dir.mkdir(parents=True, exist_ok=True)
+    (suite_dir / "test.yaml").write_text("runner: tenzir\n", encoding="utf-8")
+    script = suite_dir / "example.sh"
+    script.write_text(
+        """#!/bin/sh
+# runner: tenzir
+
+echo ok
+""",
+        encoding="utf-8",
+    )
+    run._clear_directory_config_cache()
+
+    config = run.parse_test_config(script)
+
+    assert config["runner"] == "tenzir"
+
+
+def test_parse_tql_runner_keeps_directory_runner_default(
+    tmp_path: Path, configured_root: Path
+) -> None:
+    suite_dir = tmp_path / "tests" / "mixed"
+    suite_dir.mkdir(parents=True, exist_ok=True)
+    (suite_dir / "test.yaml").write_text("runner: tenzir\n", encoding="utf-8")
+    test_file = suite_dir / "example.tql"
+    test_file.write_text("version\nwrite_json\n", encoding="utf-8")
+    run._clear_directory_config_cache()
+
+    config = run.parse_test_config(test_file)
+
+    assert config["runner"] == "tenzir"
+
+
 def test_parse_test_config_retry_option(tmp_path: Path, configured_root: Path) -> None:
     test_file = tmp_path / "flaky.tql"
     test_file.write_text(


### PR DESCRIPTION
## Summary

Ensure that `.sh` test files always default to the "shell" runner, even when a directory-level `test.yaml` specifies a different runner (e.g., `tenzir`). An explicit `runner:` declaration in the test file frontmatter still takes precedence over this file-suffix-based default.

## Problem

Previously, a directory-level `runner:` setting in `test.yaml` would override the file-suffix-based runner detection, causing `.sh` scripts to be routed through an incorrect runner (e.g., the `tenzir` runner).

## Solution

The fix tracks whether the runner was explicitly set via frontmatter:
- Frontmatter parsing now sets a flag when a `runner:` option is encountered
- After frontmatter parsing, if the file has a `.sh` suffix and no explicit runner was set, the runner is forced to "shell" from `_DEFAULT_RUNNER_BY_SUFFIX`
- Directory-level defaults no longer inadvertently route shell scripts through a wrong runner
- Explicit frontmatter declarations still take precedence over the shell default

## Testing

Three new tests cover the behavior:
1. `.sh` files override directory-level runner default
2. Explicit frontmatter overrides the `.sh` suffix default
3. `.tql` files still respect directory-level runner defaults