### PR TITLE
Avoid Python backtraces on Ctrl+C interrupts

### DIFF
--- a/changelog/unreleased/avoid-python-backtraces-on-ctrlc-interrupts.md
+++ b/changelog/unreleased/avoid-python-backtraces-on-ctrlc-interrupts.md
@@ -1,6 +1,7 @@
 ---
 title: Avoid Python backtraces on Ctrl+C interrupts
 type: bugfix
+pr: 31
 authors:
   - mavam
   - codex

--- a/changelog/unreleased/avoid-python-backtraces-on-ctrlc-interrupts.md
+++ b/changelog/unreleased/avoid-python-backtraces-on-ctrlc-interrupts.md
@@ -1,0 +1,10 @@
+---
+title: Avoid Python backtraces on Ctrl+C interrupts
+type: bugfix
+authors:
+  - mavam
+  - codex
+created: 2026-02-25T10:23:12.108744Z
+---
+
+Interrupting test runs with Ctrl+C now exits cleanly without leaking Python tracebacks from subprocess or fixture startup/teardown paths. Interrupt-shaped errors (including nested causes with signal-style return codes such as 130) are treated as graceful cancellation so the CLI reports interrupted tests instead of crashing.


### PR DESCRIPTION
## Summary

Interrupting test runs with Ctrl+C now exits cleanly without leaking Python tracebacks from subprocess or fixture startup/teardown paths. Interrupt-shaped errors (including nested causes with signal-style return codes such as 130) are treated as graceful cancellation.

Key improvements:
- Added `_exception_is_interrupt()` utility to detect interrupt-shaped exceptions, including KeyboardInterrupt and CalledProcessError with signal exit codes, while traversing exception chains
- Handles CalledProcessError during version probing in `run_cli()` gracefully
- Catches and handles interrupt exceptions propagated from worker threads
- Moves the interrupted check earlier to exit cleanly before purge/summary operations

## Tests Added

- `test_exception_is_interrupt_handles_nested_causes` — verifies exception chain traversal
- `test_exception_is_interrupt_ignores_non_interrupt_errors` — ensures non-interrupt errors are not caught
- `test_run_cli_handles_interrupt_during_version_probe` — tests CalledProcessError handling
- `test_run_cli_handles_interrupt_exception_from_worker` — tests worker thread interrupts

## Test Plan

- Unit tests validate interrupt detection and exception chain traversal
- Integration tests verify clean exit paths during version probing and worker execution
- Manual testing: `Ctrl+C` during test runs should exit cleanly without Python traceback

🤖 Generated with Claude Code