### PR TITLE
Improve parallel suite scheduling and correctness

### DIFF
--- a/changelog/unreleased/improve-parallel-suite-scheduling-and-correctness-checks.md
+++ b/changelog/unreleased/improve-parallel-suite-scheduling-and-correctness-checks.md
@@ -1,0 +1,14 @@
+---
+title: Improve parallel suite scheduling and correctness checks
+type: bugfix
+authors:
+  - mavam
+  - codex
+created: 2026-02-26T10:19:21.558254Z
+---
+
+Parallel suites are now scheduled more reliably when running with `--jobs > 1`, so interdependent tests (for example publisher/subscriber pairs) start together sooner instead of being delayed behind large backlogs of unrelated tests.
+
+This update also adds an explicit correctness guard for parallel suites: you can set `suite.min_jobs` in `test.yaml` to declare the minimum job count required for valid execution. If `--jobs` is lower than `suite.min_jobs`, the run now fails fast with a clear error instead of proceeding with potentially incorrect behavior.
+
+In addition, the harness now warns when a parallel suite has more tests than available jobs, making it easier to spot cases where effective suite parallelism is capped by worker count.

--- a/changelog/unreleased/improve-parallel-suite-scheduling-and-correctness-checks.md
+++ b/changelog/unreleased/improve-parallel-suite-scheduling-and-correctness-checks.md
@@ -9,6 +9,6 @@ created: 2026-02-26T10:19:21.558254Z
 
 Parallel suites are now scheduled more reliably when running with `--jobs > 1`, so interdependent tests (for example publisher/subscriber pairs) start together sooner instead of being delayed behind large backlogs of unrelated tests.
 
-This update also adds an explicit correctness guard for parallel suites: you can set `suite.min_jobs` in `test.yaml` to declare the minimum job count required for valid execution. If `--jobs` is lower than `suite.min_jobs`, the run now fails fast with a clear error instead of proceeding with potentially incorrect behavior.
+This update also adds an explicit correctness guard for parallel suites: you can set `suite.min_jobs` in `test.yaml` to declare the minimum job count required for valid execution. The run now fails fast if `--jobs` is lower than `suite.min_jobs`, and it also fails hard when a parallel suite cannot reserve at least `min_jobs` workers at runtime (for example under slot contention), instead of proceeding under-provisioned.
 
 In addition, the harness now warns when a parallel suite has more tests than available jobs, making it easier to spot cases where effective suite parallelism is capped by worker count.

--- a/src/tenzir_test/run.py
+++ b/src/tenzir_test/run.py
@@ -4330,6 +4330,11 @@ def _log_suite_event(
 
 
 class Worker:
+    # Default locks are shared so multiple workers created with shared resources
+    # remain synchronized even when callers omit explicit lock arguments.
+    _DEFAULT_SLOT_LOCK = threading.Lock()
+    _DEFAULT_QUEUE_LOCK = threading.Lock()
+
     def __init__(
         self,
         queue: list[RunnerQueueItem],
@@ -4355,8 +4360,8 @@ class Worker:
         self._run_skipped_selector = run_skipped_selector or RunSkippedSelector()
         self._jobs = max(1, jobs if jobs is not None else get_default_jobs())
         self._test_slots = test_slots or threading.BoundedSemaphore(self._jobs)
-        self._slot_lock = slot_lock or threading.Lock()
-        self._queue_lock = queue_lock or threading.Lock()
+        self._slot_lock = slot_lock or self._DEFAULT_SLOT_LOCK
+        self._queue_lock = queue_lock or self._DEFAULT_QUEUE_LOCK
         self._suite_queue_state = suite_queue_state or SuiteQueueState(
             pending_items=_count_suite_queue_items(queue)
         )

--- a/tests/test_python_runner.py
+++ b/tests/test_python_runner.py
@@ -72,7 +72,7 @@ def test_jsonify_config_converts_skip_config() -> None:
     converted = _jsonify_config(config_payload)
 
     assert converted["fixtures"] == ["sink", "mysql"]
-    assert converted["suite"] == {"name": "meta", "mode": "sequential"}
+    assert converted["suite"] == {"name": "meta", "mode": "sequential", "min_jobs": None}
     assert converted["modes"] == ["parallel"]
     assert converted["skip"] == {
         "reason": None,
@@ -237,6 +237,7 @@ def test_python_runner_context_serializes_suite_mode(
         assert payload["config"]["suite"] == {
             "name": "fixture-suite",
             "mode": suite_mode,
+            "min_jobs": None,
         }
         return _DummyCompleted(stdout=b"payload", stderr=b"")
 

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -884,6 +884,16 @@ def test_worker_parallel_suites_honor_shared_jobs_budget(
         run.apply_settings(original_settings)
 
 
+def test_worker_defaults_share_sync_locks_for_shared_resources() -> None:
+    queue: list[run.RunnerQueueItem] = []
+    test_slots = threading.BoundedSemaphore(2)
+    first = run.Worker(queue, update=False, coverage=False, jobs=2, test_slots=test_slots)
+    second = run.Worker(queue, update=False, coverage=False, jobs=2, test_slots=test_slots)
+
+    assert first._queue_lock is second._queue_lock
+    assert first._slot_lock is second._slot_lock
+
+
 def test_workers_prioritize_parallel_suites_before_standalone_tests(tmp_path: Path) -> None:
     original_settings = config.Settings(
         root=run.ROOT,


### PR DESCRIPTION
## Summary

Parallel suite scheduling improvements to prevent concurrency bugs and ensure correct test execution:

- **Suite prioritization**: Workers now dequeue parallel suites before standalone tests, ensuring interdependent test groups (e.g., publisher/subscriber pairs) start together instead of being delayed by unrelated test backlogs

- **`min_jobs` correctness guard**: Parallel suites can declare `min_jobs` in `test.yaml` to specify the minimum `--jobs` value required for correct execution. The harness fails fast with a clear error if `--jobs` is too low

- **Oversubscription warning**: When a parallel suite has more tests than available jobs, the harness emits a warning so users know effective parallelism is capped

- **Slot acquisition improvements**: Parallel suites acquire all slots upfront and run members without per-member slot acquisition. New synchronization primitives (`slot_lock` and `queue_lock`) prevent races when multiple workers share slot budgets and work queues

## Documentation

Companion docs PR: tenzir/docs#227

## Test Plan

- All existing tests pass
- New unit tests for `_validate_parallel_suite_min_jobs`, `_warn_parallel_suite_oversubscription`, `_pop_next_queue_item`
- New integration tests for min_jobs guard at Worker and CLI level
- New test verifying suite prioritization ordering

🤖 Generated with Claude Code