### PR TITLE
Preserve baselines for skipped tests

### DIFF
--- a/.pi/settings.json
+++ b/.pi/settings.json
@@ -1,7 +1,5 @@
 {
   "packages": [
-    "npm:pi-formatter",
-    "npm:pi-tenzir-ship",
-    "npm:pi-tenzir-dev"
+    "npm:pi-formatter"
   ]
 }

--- a/changelog/unreleased/skipped-tests-preserve-existing-baseline-files.md
+++ b/changelog/unreleased/skipped-tests-preserve-existing-baseline-files.md
@@ -1,0 +1,14 @@
+---
+title: Skipped tests preserve existing baseline files
+type: bugfix
+authors:
+  - mavam
+  - codex
+created: 2026-03-10T16:49:44.144342Z
+---
+
+Skipping a test no longer modifies its baseline file. Previously, running
+with `--update` would overwrite the baseline of a skipped test with an empty
+file, and running without `--update` would fail if the baseline was non-empty.
+Skipped tests now leave existing baselines untouched, so toggling a skip
+condition no longer causes unrelated baseline churn.

--- a/src/tenzir_test/run.py
+++ b/src/tenzir_test/run.py
@@ -4291,21 +4291,6 @@ def handle_skip(reason: str, test: Path, update: bool, output_ext: str) -> bool 
         rel_path = _relativize_path(test)
         suite_suffix = _format_suite_suffix()
         print(f"{SKIP} skipped {rel_path}{suite_suffix}: {reason}")
-    ref_path = test.with_suffix(f".{output_ext}")
-    if update:
-        with ref_path.open("wb") as f:
-            f.write(b"")
-    else:
-        if ref_path.exists():
-            expected = ref_path.read_bytes()
-            if expected != b"":
-                report_failure(
-                    test,
-                    format_failure_message(
-                        f'Reference file for skipped test must be empty: "{ref_path}"'
-                    ),
-                )
-                return False
     return "skipped"
 
 

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -383,6 +383,7 @@ def test_handle_skip_uses_skip_glyph(tmp_path, capsys):
         test_path = tmp_path / "tests" / "example.tql"
         test_path.parent.mkdir(parents=True)
         test_path.touch()
+        test_path.with_suffix(".txt").write_text("existing baseline\n", encoding="utf-8")
 
         result = run.handle_skip("slow", test_path, update=False, output_ext="txt")
 
@@ -423,12 +424,37 @@ def test_handle_skip_suppressed_when_verbose_disabled(
         test_path = tmp_path / "tests" / "example.tql"
         test_path.parent.mkdir(parents=True)
         test_path.touch()
+        test_path.with_suffix(".txt").write_text("existing baseline\n", encoding="utf-8")
 
         result = run.handle_skip("slow", test_path, update=False, output_ext="txt")
 
         assert result == "skipped"
         output = capsys.readouterr().out.strip()
         assert output == ""
+    finally:
+        run.ROOT = original_root
+        run.set_verbose_output(original_verbose)
+
+
+def test_handle_skip_preserves_existing_baseline_during_update(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    original_root = run.ROOT
+    original_verbose = run.is_verbose_output()
+    try:
+        run.ROOT = tmp_path
+        run.set_verbose_output(False)
+        test_path = tmp_path / "tests" / "example.tql"
+        test_path.parent.mkdir(parents=True)
+        test_path.touch()
+        ref_path = test_path.with_suffix(".txt")
+        ref_path.write_text("existing baseline\n", encoding="utf-8")
+
+        result = run.handle_skip("slow", test_path, update=True, output_ext="txt")
+
+        assert result == "skipped"
+        assert ref_path.read_text(encoding="utf-8") == "existing baseline\n"
+        assert capsys.readouterr().out.strip() == ""
     finally:
         run.ROOT = original_root
         run.set_verbose_output(original_verbose)


### PR DESCRIPTION
## Summary
- stop treating existing baseline files as an error for skipped tests
- preserve skipped-test baselines during `--update`
- add regression tests for verbose, quiet, and update-mode skip handling

## Testing
- `uv run pytest tests/test_run.py -k 'handle_skip or run_skipped_reason_matches_static_skip_and_executes or suite_static_skip_short_circuits_fixture_activation or suite_static_skip_respects_run_skipped_selector'`
- `uv run ruff check src/tenzir_test/run.py tests/test_run.py`
- `uv run ruff format --check src/tenzir_test/run.py tests/test_run.py`

Linear: https://linear.app/tenzir/issue/TNZ-438/dont-show-an-error-like-output-for-skipped-tests

<sub>resolves TNZ-438</sub>