### PR TITLE
Support per-test fixture-unavailable skips

### DIFF
--- a/changelog/unreleased/per-test-fixture-unavailable-skips.md
+++ b/changelog/unreleased/per-test-fixture-unavailable-skips.md
@@ -1,0 +1,20 @@
+---
+title: Per-test fixture-unavailable skips
+type: bugfix
+authors:
+  - mavam
+  - codex
+pr: 35
+created: 2026-04-22T16:19:25.471352Z
+---
+
+The test harness now honors `skip: {on: fixture-unavailable}` for fixtures that are selected by individual tests:
+
+```yaml
+skip:
+  on: fixture-unavailable
+fixtures:
+  - optional-service
+```
+
+This lets parameterized per-test fixtures skip only the tests that need the unavailable service. Suite fixtures still require the opt-in in directory-level `test.yaml`, so one test's frontmatter cannot control the whole suite.

--- a/example-project/README.md
+++ b/example-project/README.md
@@ -115,7 +115,9 @@ example-project/
   raises `FixtureUnavailable` because it checks for a binary that does not
   exist. The suite's `test.yaml` opts into graceful skipping via
   `skip: {on: fixture-unavailable}`, so the test is reported as skipped rather
-  than failing the run.
+  than failing the run. For fixtures that are selected by individual tests, use
+  the same skip mapping in test frontmatter or inherit it from directory
+  defaults; the skip applies to that test's fixture activation.
 - **Capability requirements** (`tests/capability`): demonstrates suite-level
   capability probes with:
   `requires.operators: [from_gcs]` and

--- a/src/tenzir_test/fixtures/__init__.py
+++ b/src/tenzir_test/fixtures/__init__.py
@@ -469,9 +469,12 @@ class FixtureHandle:
 class FixtureUnavailable(Exception):
     """Raised by a fixture when it cannot provide its service.
 
-    When a fixture raises this during initialization (before yielding)
-    and the suite has ``skip: {on: fixture-unavailable}`` in its
-    ``test.yaml``, all tests in the suite are marked as skipped.
+    When a fixture raises this during initialization (before yielding), tests
+    can opt in to graceful skipping with ``skip: {on: fixture-unavailable}``.
+    Put the opt-in in test frontmatter for a per-test fixture, or in a
+    directory-level ``test.yaml`` for shared defaults and suite fixtures. If a
+    suite fixture is unavailable and the suite opts in, all tests in the suite
+    are marked as skipped.
 
     Without the opt-in config, the exception propagates normally and
     causes a test failure.

--- a/src/tenzir_test/run.py
+++ b/src/tenzir_test/run.py
@@ -69,8 +69,10 @@ class SkipConfig:
     * **Static skip** -- the test is unconditionally skipped with a reason
       string (``skip: "reason"`` in YAML).
     * **Conditional skip** -- the test is skipped when one of the configured
-      suite conditions occurs (e.g. ``fixture-unavailable`` or
-      ``capability-unavailable`` in directory-level ``test.yaml``).
+      conditions occurs. ``fixture-unavailable`` applies at the fixture
+      activation point, so it can be configured in directory defaults or test
+      frontmatter. ``capability-unavailable`` applies to suite-level capability
+      probes and is only valid in directory-level ``test.yaml`` files.
     """
 
     reason: str | None = None
@@ -152,14 +154,6 @@ class SkipConfig:
             return cls(reason=value)
 
         if isinstance(value, dict):
-            if origin != "directory":
-                _raise_config_error(
-                    location,
-                    f"'skip' mapping form (e.g. {{on: {SKIP_ON_FIXTURE_UNAVAILABLE}}}) "
-                    "is only valid in directory-level test.yaml files, "
-                    "not in test frontmatter",
-                    line_number,
-                )
             normalized = cls._normalize_dict_keys(value)
             unknown_keys = set(normalized.keys()) - cls._VALID_DICT_KEYS
             if unknown_keys:
@@ -210,6 +204,14 @@ class SkipConfig:
                     f"'skip.on' must be one of "
                     f"{', '.join(repr(v) for v in sorted(cls._VALID_ON_VALUES))}, "
                     f"got '{invalid_values[0]}'",
+                    line_number,
+                )
+            if origin != "directory" and SKIP_ON_CAPABILITY_UNAVAILABLE in normalized_on_values:
+                _raise_config_error(
+                    location,
+                    f"'skip.on' value '{SKIP_ON_CAPABILITY_UNAVAILABLE}' "
+                    "is only valid in directory-level test.yaml files, "
+                    "not in test frontmatter",
                     line_number,
                 )
             reason = normalized.get("reason")
@@ -2419,6 +2421,14 @@ def _get_directory_defaults(directory: Path) -> TestConfig:
     return dict(config)
 
 
+def _get_suite_directory_config(suite: SuiteInfo, *, coverage: bool) -> TestConfig:
+    config = _get_directory_defaults(suite.directory)
+    if coverage:
+        timeout_value = cast(int, config["timeout"])
+        config["timeout"] = timeout_value * 5
+    return config
+
+
 def _resolve_suite_for_test(test: Path) -> SuiteInfo | None:
     directory_config = _load_directory_config(test.parent)
     suite_value = _suite_config_from_value(directory_config.values.get("suite"))
@@ -4227,6 +4237,8 @@ def run_simple_test(
     except subprocess.CalledProcessError as e:
         report_failure(test, format_failure_message(f"subprocess error: {e}"))
         return False
+    except fixtures_impl.FixtureUnavailable:
+        raise
     except Exception as e:
         report_failure(test, format_failure_message(f"unexpected exception: {e}"))
         return False
@@ -4263,6 +4275,14 @@ def _compose_skip_reason(
     if has_exc:
         return exception_reason  # type: ignore[return-value]
     return fallback
+
+
+def _fixture_unavailable_skip_reason(
+    skip_cfg: "SkipConfig | None",
+    exc: fixtures_impl.FixtureUnavailable,
+) -> str:
+    configured_reason = skip_cfg.reason if isinstance(skip_cfg, SkipConfig) else None
+    return _compose_skip_reason(configured_reason, str(exc))
 
 
 def _run_fixture_assertions_for_test(
@@ -4502,7 +4522,7 @@ class Worker:
                 return 0
             time.sleep(0.01)
 
-    def _record_static_skip(
+    def _record_test_skip(
         self,
         *,
         test_item: TestQueueItem,
@@ -4523,6 +4543,40 @@ class Worker:
             summary.record_fixture_outcome(_fixture_names(fixtures), "skipped")
         summary.skipped += 1
         summary.skipped_paths.append(rel_path)
+
+    def _record_static_skip(
+        self,
+        *,
+        test_item: TestQueueItem,
+        fixtures: tuple[fixtures_impl.FixtureSpec, ...],
+        reason: str,
+        summary: Summary,
+    ) -> None:
+        self._record_test_skip(
+            test_item=test_item,
+            fixtures=fixtures,
+            reason=reason,
+            summary=summary,
+        )
+
+    def _skip_test_with_reason(
+        self,
+        *,
+        test_item: TestQueueItem,
+        fixtures: tuple[fixtures_impl.FixtureSpec, ...],
+        displayed_reason: str,
+        summary: Summary,
+    ) -> bool:
+        if self._run_skipped_selector.should_run_skipped(reason=displayed_reason):
+            self._increment_run_skipped_match_count()
+            return False
+        self._record_test_skip(
+            test_item=test_item,
+            fixtures=fixtures,
+            reason=displayed_reason,
+            summary=summary,
+        )
+        return True
 
     def _skip_suite_with_reason(
         self,
@@ -4826,11 +4880,15 @@ class Worker:
                     )
             primary_test = tests[0].path
             try:
-                primary_config = parse_test_config(primary_test, coverage=self._coverage)
+                parse_test_config(primary_test, coverage=self._coverage)
             except ValueError as exc:
                 raise RuntimeError(
                     f"failed to parse suite config for {primary_test}: {exc}"
                 ) from exc
+            suite_config = _get_suite_directory_config(
+                suite_item.suite,
+                coverage=self._coverage,
+            )
             # Avoid activating suite fixtures when every suite member is statically skipped.
             static_skip_plan = self._suite_static_skip_plan(suite_item)
             if static_skip_plan is not None:
@@ -4842,9 +4900,9 @@ class Worker:
                         summary=summary,
                     )
                 return
-            inputs_override = typing.cast(str | None, primary_config.get("inputs"))
+            inputs_override = typing.cast(str | None, suite_config.get("inputs"))
             env, config_args = get_test_env_and_config_args(primary_test, inputs=inputs_override)
-            config_package_dirs = cast(tuple[str, ...], primary_config.get("package_dirs", tuple()))
+            config_package_dirs = cast(tuple[str, ...], suite_config.get("package_dirs", tuple()))
             additional_package_dirs: list[str] = []
             for entry in config_package_dirs:
                 additional_package_dirs.extend(_expand_package_dirs(Path(entry)))
@@ -4867,8 +4925,8 @@ class Worker:
                 merged_dirs = _deduplicate_package_dirs(package_dir_candidates)
                 env["TENZIR_PACKAGE_DIRS"] = ",".join(merged_dirs)
                 config_args = list(config_args) + [f"--package-dirs={','.join(merged_dirs)}"]
-            skip_cfg = cast(SkipConfig | None, primary_config.get("skip"))
-            requires_cfg = cast(RequiresConfig | None, primary_config.get("requires"))
+            skip_cfg = cast(SkipConfig | None, suite_config.get("skip"))
+            requires_cfg = cast(RequiresConfig | None, suite_config.get("requires"))
             if isinstance(requires_cfg, RequiresConfig) and requires_cfg.has_requirements:
                 missing_requirements = self._evaluate_suite_requirements(
                     suite_item=suite_item,
@@ -4904,7 +4962,7 @@ class Worker:
             context_token = fixtures_impl.push_context(
                 fixtures_impl.FixtureContext(
                     test=primary_test,
-                    config=typing.cast(dict[str, Any], primary_config),
+                    config=typing.cast(dict[str, Any], suite_config),
                     coverage=self._coverage,
                     env=env,
                     config_args=tuple(config_args),
@@ -4937,7 +4995,7 @@ class Worker:
                     and skip_cfg.allows_condition(SKIP_ON_FIXTURE_UNAVAILABLE)
                 ):
                     raise
-                reason = _compose_skip_reason(skip_cfg.reason, str(exc))
+                reason = _fixture_unavailable_skip_reason(skip_cfg, exc)
                 displayed_reason = f"fixture unavailable: {reason}"
                 if not self._skip_suite_with_reason(
                     suite_item=suite_item,
@@ -4981,6 +5039,7 @@ class Worker:
         retry_limit = 1
         config: TestConfig | None = None
         fixture_assertions: dict[str, Any] = {}
+        skip_cfg: SkipConfig | None = None
         parse_error: str | None = None
         try:
             config = parse_test_config(test_path, coverage=self._coverage)
@@ -5023,7 +5082,8 @@ class Worker:
                         summary=summary,
                     )
                     return False
-            # Conditional skips are suite-level — _run_suite handles them.
+            # Capability skips are suite-level. Fixture-unavailable skips can
+            # also apply to per-test fixture activation below.
         if parse_error is not None:
             message = format_failure_message(parse_error)
             report_failure(test_path, message)
@@ -5093,6 +5153,34 @@ class Worker:
                         _request_interrupt()
                         interrupted = True
                         outcome = False
+                    except fixtures_impl.FixtureUnavailable as exc:
+                        if isinstance(skip_cfg, SkipConfig) and skip_cfg.allows_condition(
+                            SKIP_ON_FIXTURE_UNAVAILABLE
+                        ):
+                            reason = _fixture_unavailable_skip_reason(skip_cfg, exc)
+                            displayed_reason = f"fixture unavailable: {reason}"
+                            if self._skip_test_with_reason(
+                                test_item=test_item,
+                                fixtures=fixtures,
+                                displayed_reason=displayed_reason,
+                                summary=summary,
+                            ):
+                                return False
+                            raise
+                        report_failure(
+                            test_path,
+                            format_failure_message(
+                                f"fixture unavailable: {_compose_skip_reason(None, str(exc))}"
+                            ),
+                        )
+                        outcome = False
+                        final_interrupted = False
+                        final_outcome = outcome
+                        summary.record_assertion_checks(
+                            total=assertion_tally.total,
+                            failed=assertion_tally.failed,
+                        )
+                        break
                     except Exception as exc:
                         is_fixture_assertion = str(exc).startswith("fixture assertion failed:")
                         error_message = (

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -5562,6 +5562,252 @@ def test_worker_fixture_unavailable_not_skipped_for_capability_only_condition(
         run.apply_settings(original_settings)
 
 
+def test_worker_per_test_fixture_unavailable_skip_from_frontmatter(tmp_path: Path) -> None:
+    original_settings = config.Settings(
+        root=run.ROOT,
+        tenzir_binary=run.TENZIR_BINARY,
+        tenzir_node_binary=run.TENZIR_NODE_BINARY,
+    )
+    run.apply_settings(
+        config.Settings(
+            root=tmp_path,
+            tenzir_binary=run.TENZIR_BINARY,
+            tenzir_node_binary=run.TENZIR_NODE_BINARY,
+        )
+    )
+
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir(parents=True)
+    test_path = tests_dir / "frontmatter-fixture.tql"
+    test_path.write_text(
+        """---
+skip:
+  on: fixture-unavailable
+  reason: optional dependency
+fixtures:
+  - per_test_unavailable_fixture
+---
+
+version
+write_json
+""",
+        encoding="utf-8",
+    )
+    run._clear_directory_config_cache()
+
+    activation_count = 0
+    previous_factory = fixture_api._FACTORIES.get("per_test_unavailable_fixture")
+
+    @fixture_api.fixture(name="per_test_unavailable_fixture", replace=True)
+    def per_test_unavailable_fixture():
+        nonlocal activation_count
+        activation_count += 1
+        raise fixture_api.FixtureUnavailable("binary missing")
+        yield {}  # type: ignore[misc]
+
+    try:
+        queue = run._build_queue_from_paths([test_path], coverage=False)
+        assert len(queue) == 1
+        assert isinstance(queue[0], run.TestQueueItem)
+        worker = run.Worker(queue, update=False, coverage=False)
+        worker.start()
+        summary = worker.join()
+        assert summary.total == 1
+        assert summary.skipped == 1
+        assert summary.failed == 0
+        assert activation_count == 1
+        assert summary.runner_stats["tenzir"].skipped == 1
+        assert summary.fixture_stats["per_test_unavailable_fixture"].skipped == 1
+    finally:
+        run._clear_directory_config_cache()
+        if previous_factory is None:
+            fixture_api._FACTORIES.pop("per_test_unavailable_fixture", None)
+        else:
+            fixture_api._FACTORIES["per_test_unavailable_fixture"] = previous_factory
+        run.apply_settings(original_settings)
+
+
+def test_worker_directory_fixture_unavailable_skip_with_per_test_options(
+    tmp_path: Path,
+) -> None:
+    original_settings = config.Settings(
+        root=run.ROOT,
+        tenzir_binary=run.TENZIR_BINARY,
+        tenzir_node_binary=run.TENZIR_NODE_BINARY,
+    )
+    run.apply_settings(
+        config.Settings(
+            root=tmp_path,
+            tenzir_binary=run.TENZIR_BINARY,
+            tenzir_node_binary=run.TENZIR_NODE_BINARY,
+        )
+    )
+
+    tests_dir = tmp_path / "tests" / "parameterized"
+    tests_dir.mkdir(parents=True)
+    (tests_dir / "test.yaml").write_text(
+        "skip:\n  on: fixture-unavailable\n  reason: optional service\n",
+        encoding="utf-8",
+    )
+    tests: list[Path] = []
+    for label in ("alpha", "beta"):
+        path = tests_dir / f"{label}.tql"
+        path.write_text(
+            f"""---
+fixtures:
+  - per_test_parameterized_fixture:
+      label: {label}
+---
+
+version
+write_json
+""",
+            encoding="utf-8",
+        )
+        tests.append(path)
+    run._clear_directory_config_cache()
+
+    activation_labels: list[str] = []
+    previous_factory = fixture_api._FACTORIES.get("per_test_parameterized_fixture")
+
+    @fixture_api.fixture(name="per_test_parameterized_fixture", replace=True)
+    def per_test_parameterized_fixture():
+        options = fixture_api.current_options("per_test_parameterized_fixture")
+        label = options.get("label", "missing")
+        activation_labels.append(label)
+        raise fixture_api.FixtureUnavailable(f"{label} service missing")
+        yield {}  # type: ignore[misc]
+
+    try:
+        queue = run._build_queue_from_paths(tests, coverage=False)
+        assert len(queue) == 2
+        assert all(isinstance(item, run.TestQueueItem) for item in queue)
+        worker = run.Worker(queue, update=False, coverage=False)
+        worker.start()
+        summary = worker.join()
+        assert summary.total == 2
+        assert summary.skipped == 2
+        assert summary.failed == 0
+        assert sorted(activation_labels) == ["alpha", "beta"]
+    finally:
+        run._clear_directory_config_cache()
+        if previous_factory is None:
+            fixture_api._FACTORIES.pop("per_test_parameterized_fixture", None)
+        else:
+            fixture_api._FACTORIES["per_test_parameterized_fixture"] = previous_factory
+        run.apply_settings(original_settings)
+
+
+def test_worker_per_test_fixture_unavailable_without_skip_fails(tmp_path: Path) -> None:
+    original_settings = config.Settings(
+        root=run.ROOT,
+        tenzir_binary=run.TENZIR_BINARY,
+        tenzir_node_binary=run.TENZIR_NODE_BINARY,
+    )
+    run.apply_settings(
+        config.Settings(
+            root=tmp_path,
+            tenzir_binary=run.TENZIR_BINARY,
+            tenzir_node_binary=run.TENZIR_NODE_BINARY,
+        )
+    )
+
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir(parents=True)
+    test_path = tests_dir / "missing-fixture.tql"
+    test_path.write_text(
+        """---
+fixtures:
+  - per_test_unavailable_fixture
+---
+
+version
+write_json
+""",
+        encoding="utf-8",
+    )
+    run._clear_directory_config_cache()
+
+    previous_factory = fixture_api._FACTORIES.get("per_test_unavailable_fixture")
+
+    @fixture_api.fixture(name="per_test_unavailable_fixture", replace=True)
+    def per_test_unavailable_fixture():
+        raise fixture_api.FixtureUnavailable("binary missing")
+        yield {}  # type: ignore[misc]
+
+    try:
+        queue = run._build_queue_from_paths([test_path], coverage=False)
+        worker = run.Worker(queue, update=False, coverage=False)
+        worker.start()
+        summary = worker.join()
+        assert summary.total == 1
+        assert summary.failed == 1
+        assert summary.skipped == 0
+    finally:
+        run._clear_directory_config_cache()
+        if previous_factory is None:
+            fixture_api._FACTORIES.pop("per_test_unavailable_fixture", None)
+        else:
+            fixture_api._FACTORIES["per_test_unavailable_fixture"] = previous_factory
+        run.apply_settings(original_settings)
+
+
+def test_worker_run_skipped_matches_per_test_fixture_unavailable_skip(tmp_path: Path) -> None:
+    original_settings = config.Settings(
+        root=run.ROOT,
+        tenzir_binary=run.TENZIR_BINARY,
+        tenzir_node_binary=run.TENZIR_NODE_BINARY,
+    )
+    run.apply_settings(
+        config.Settings(
+            root=tmp_path,
+            tenzir_binary=run.TENZIR_BINARY,
+            tenzir_node_binary=run.TENZIR_NODE_BINARY,
+        )
+    )
+
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir(parents=True)
+    test_path = tests_dir / "run-skipped-fixture.tql"
+    test_path.write_text(
+        """---
+skip:
+  on: fixture-unavailable
+fixtures:
+  - per_test_unavailable_fixture
+---
+
+version
+write_json
+""",
+        encoding="utf-8",
+    )
+    run._clear_directory_config_cache()
+
+    previous_factory = fixture_api._FACTORIES.get("per_test_unavailable_fixture")
+
+    @fixture_api.fixture(name="per_test_unavailable_fixture", replace=True)
+    def per_test_unavailable_fixture():
+        raise fixture_api.FixtureUnavailable("binary missing")
+        yield {}  # type: ignore[misc]
+
+    try:
+        queue = run._build_queue_from_paths([test_path], coverage=False)
+        selector = run.RunSkippedSelector.from_cli(reason_patterns=("fixture unavailable*",))
+        worker = run.Worker(queue, update=False, coverage=False, run_skipped_selector=selector)
+        worker.start()
+        with pytest.raises(fixture_api.FixtureUnavailable, match="binary missing"):
+            worker.join()
+        assert worker.run_skipped_match_count == 1
+    finally:
+        run._clear_directory_config_cache()
+        if previous_factory is None:
+            fixture_api._FACTORIES.pop("per_test_unavailable_fixture", None)
+        else:
+            fixture_api._FACTORIES["per_test_unavailable_fixture"] = previous_factory
+        run.apply_settings(original_settings)
+
+
 # --- Tests for FixtureUnavailable handling in Worker._run_suite (TST-1, TST-4, TST-6) ---
 
 
@@ -6055,4 +6301,170 @@ def test_worker_suite_fixture_unavailable_skips_tests_with_per_test_config(
             fixture_api._FACTORIES.pop("available_fixture", None)
         else:
             fixture_api._FACTORIES["available_fixture"] = previous_available
+        run.apply_settings(original_settings)
+
+
+def test_worker_suite_fixture_unavailable_ignores_first_member_frontmatter_skip(
+    tmp_path: Path,
+) -> None:
+    original_settings = config.Settings(
+        root=run.ROOT,
+        tenzir_binary=run.TENZIR_BINARY,
+        tenzir_node_binary=run.TENZIR_NODE_BINARY,
+    )
+    run.apply_settings(
+        config.Settings(
+            root=tmp_path,
+            tenzir_binary=run.TENZIR_BINARY,
+            tenzir_node_binary=run.TENZIR_NODE_BINARY,
+        )
+    )
+
+    suite_dir = tmp_path / "tests" / "context"
+    suite_dir.mkdir(parents=True)
+    (suite_dir / "test.yaml").write_text(
+        "suite: context\nfixtures:\n  - unavailable_fixture\n",
+        encoding="utf-8",
+    )
+    first_test = suite_dir / "01-test.tql"
+    first_test.write_text(
+        "---\nskip:\n  on: fixture-unavailable\n---\nversion\nwrite_json\n",
+        encoding="utf-8",
+    )
+    second_test = suite_dir / "02-test.tql"
+    second_test.write_text("version\nwrite_json\n", encoding="utf-8")
+    run._clear_directory_config_cache()
+
+    previous_factory = fixture_api._FACTORIES.get("unavailable_fixture")
+
+    @fixture_api.fixture(name="unavailable_fixture", replace=True)
+    def unavailable_fixture():
+        raise fixture_api.FixtureUnavailable("docker not found")
+        yield {}  # type: ignore[misc]
+
+    try:
+        queue = run._build_queue_from_paths([first_test, second_test], coverage=False)
+        assert len(queue) == 1
+        worker = run.Worker(queue, update=False, coverage=False)
+        worker.start()
+        with pytest.raises(fixture_api.FixtureUnavailable, match="docker not found"):
+            worker.join()
+    finally:
+        run._clear_directory_config_cache()
+        if previous_factory is None:
+            fixture_api._FACTORIES.pop("unavailable_fixture", None)
+        else:
+            fixture_api._FACTORIES["unavailable_fixture"] = previous_factory
+        run.apply_settings(original_settings)
+
+
+def test_worker_suite_fixture_unavailable_ignores_later_member_frontmatter_skip(
+    tmp_path: Path,
+) -> None:
+    original_settings = config.Settings(
+        root=run.ROOT,
+        tenzir_binary=run.TENZIR_BINARY,
+        tenzir_node_binary=run.TENZIR_NODE_BINARY,
+    )
+    run.apply_settings(
+        config.Settings(
+            root=tmp_path,
+            tenzir_binary=run.TENZIR_BINARY,
+            tenzir_node_binary=run.TENZIR_NODE_BINARY,
+        )
+    )
+
+    suite_dir = tmp_path / "tests" / "context"
+    suite_dir.mkdir(parents=True)
+    (suite_dir / "test.yaml").write_text(
+        "suite: context\nfixtures:\n  - unavailable_fixture\n",
+        encoding="utf-8",
+    )
+    first_test = suite_dir / "01-test.tql"
+    first_test.write_text("version\nwrite_json\n", encoding="utf-8")
+    second_test = suite_dir / "02-test.tql"
+    second_test.write_text(
+        "---\nskip:\n  on: fixture-unavailable\n---\nversion\nwrite_json\n",
+        encoding="utf-8",
+    )
+    run._clear_directory_config_cache()
+
+    previous_factory = fixture_api._FACTORIES.get("unavailable_fixture")
+
+    @fixture_api.fixture(name="unavailable_fixture", replace=True)
+    def unavailable_fixture():
+        raise fixture_api.FixtureUnavailable("docker not found")
+        yield {}  # type: ignore[misc]
+
+    try:
+        queue = run._build_queue_from_paths([first_test, second_test], coverage=False)
+        assert len(queue) == 1
+        worker = run.Worker(queue, update=False, coverage=False)
+        worker.start()
+        with pytest.raises(fixture_api.FixtureUnavailable, match="docker not found"):
+            worker.join()
+    finally:
+        run._clear_directory_config_cache()
+        if previous_factory is None:
+            fixture_api._FACTORIES.pop("unavailable_fixture", None)
+        else:
+            fixture_api._FACTORIES["unavailable_fixture"] = previous_factory
+        run.apply_settings(original_settings)
+
+
+def test_worker_suite_fixture_unavailable_uses_directory_skip_with_member_static_skip(
+    tmp_path: Path,
+) -> None:
+    original_settings = config.Settings(
+        root=run.ROOT,
+        tenzir_binary=run.TENZIR_BINARY,
+        tenzir_node_binary=run.TENZIR_NODE_BINARY,
+    )
+    run.apply_settings(
+        config.Settings(
+            root=tmp_path,
+            tenzir_binary=run.TENZIR_BINARY,
+            tenzir_node_binary=run.TENZIR_NODE_BINARY,
+        )
+    )
+
+    suite_dir = tmp_path / "tests" / "context"
+    suite_dir.mkdir(parents=True)
+    (suite_dir / "test.yaml").write_text(
+        "suite: context\n"
+        "skip:\n  on: fixture-unavailable\n  reason: suite dependency\n"
+        "fixtures:\n  - unavailable_fixture\n",
+        encoding="utf-8",
+    )
+    first_test = suite_dir / "01-test.tql"
+    first_test.write_text(
+        "---\nskip: per-test maintenance\n---\nversion\nwrite_json\n",
+        encoding="utf-8",
+    )
+    second_test = suite_dir / "02-test.tql"
+    second_test.write_text("version\nwrite_json\n", encoding="utf-8")
+    run._clear_directory_config_cache()
+
+    previous_factory = fixture_api._FACTORIES.get("unavailable_fixture")
+
+    @fixture_api.fixture(name="unavailable_fixture", replace=True)
+    def unavailable_fixture():
+        raise fixture_api.FixtureUnavailable("docker not found")
+        yield {}  # type: ignore[misc]
+
+    try:
+        queue = run._build_queue_from_paths([first_test, second_test], coverage=False)
+        assert len(queue) == 1
+        worker = run.Worker(queue, update=False, coverage=False)
+        worker.start()
+        summary = worker.join()
+        assert summary.total == 2
+        assert summary.skipped == 2
+        assert summary.failed == 0
+    finally:
+        run._clear_directory_config_cache()
+        if previous_factory is None:
+            fixture_api._FACTORIES.pop("unavailable_fixture", None)
+        else:
+            fixture_api._FACTORIES["unavailable_fixture"] = previous_factory
         run.apply_settings(original_settings)

--- a/tests/test_run_config.py
+++ b/tests/test_run_config.py
@@ -1187,13 +1187,16 @@ def test_skip_dict_rejects_non_string_reason() -> None:
         )
 
 
-def test_skip_dict_rejected_in_frontmatter(tmp_path: Path, configured_root: Path) -> None:
-    """Dict skip format is only valid in directory-level test.yaml, not in frontmatter."""
+def test_skip_dict_fixture_unavailable_accepts_frontmatter(
+    tmp_path: Path, configured_root: Path
+) -> None:
+    """Fixture-unavailable skip conditions are valid for per-test fixtures."""
     test_file = tmp_path / "case.tql"
     test_file.write_text(
         """---
 skip:
   on: fixture-unavailable
+  reason: optional dependency missing
 ---
 
 version
@@ -1202,7 +1205,55 @@ write_json
         encoding="utf-8",
     )
 
-    with pytest.raises(ValueError, match="'skip' mapping form.*only valid in directory-level"):
+    config = run.parse_test_config(test_file)
+
+    skip_cfg = config["skip"]
+    assert isinstance(skip_cfg, run.SkipConfig)
+    assert skip_cfg.is_conditional
+    assert skip_cfg.on_fixture_unavailable
+    assert not skip_cfg.on_capability_unavailable
+    assert skip_cfg.reason == "optional dependency missing"
+
+
+def test_skip_dict_capability_unavailable_rejected_in_frontmatter(
+    tmp_path: Path, configured_root: Path
+) -> None:
+    test_file = tmp_path / "case.tql"
+    test_file.write_text(
+        """---
+skip:
+  on: capability-unavailable
+---
+
+version
+write_json
+""",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="'skip.on' value 'capability-unavailable'.*directory"):
+        run.parse_test_config(test_file)
+
+
+def test_skip_dict_mixed_capability_condition_rejected_in_frontmatter(
+    tmp_path: Path, configured_root: Path
+) -> None:
+    test_file = tmp_path / "case.tql"
+    test_file.write_text(
+        """---
+skip:
+  on:
+    - fixture-unavailable
+    - capability-unavailable
+---
+
+version
+write_json
+""",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="'skip.on' value 'capability-unavailable'.*directory"):
         run.parse_test_config(test_file)
 
 


### PR DESCRIPTION
## 🔍 Problem

- `skip: {on: fixture-unavailable}` was rejected in test frontmatter, so individually selected or parameterized fixtures could not opt into graceful skips.
- Letting frontmatter control that condition naively makes suite fixture failures depend on one suite member's merged config.

## 🛠️ Solution

- Allow `fixture-unavailable` skip mappings in test frontmatter while keeping `capability-unavailable` directory-level only.
- Handle per-test `FixtureUnavailable` in the worker so skipped tests update summaries, runner stats, fixture stats, and `--run-skipped` matching consistently.
- Source suite fixture skip policy strictly from directory-level suite config.

## 💬 Review

- Focus on the distinction between per-test fixture activation and suite fixture activation.
- The regression tests cover frontmatter opt-in, directory defaults with per-test fixture options, non-opted-in failures, `--run-skipped`, and mixed suite/frontmatter cases.

<sub>
📚 Docs PR: tenzir/docs#274<br>
📎 Related: https://github.com/tenzir/tenzir/pull/5999
</sub>
