### PR TITLE
Add project hook lifecycle

### DIFF
--- a/changelog/unreleased/project-lifecycle-hooks.md
+++ b/changelog/unreleased/project-lifecycle-hooks.md
@@ -1,0 +1,23 @@
+---
+title: Project lifecycle hooks
+type: feature
+authors:
+  - mavam
+  - codex
+pr: 36
+created: 2026-04-27T17:43:07.867159Z
+---
+
+Projects can now register Python hooks that run at stable `tenzir-test` lifecycle points, including before settings discovery:
+
+```python
+from tenzir_test import hooks
+
+@hooks.startup
+def use_local_build(ctx):
+    ctx.prepend_path(ctx.root / "build" / "bin")
+    ctx.env["TENZIR_BINARY"] = str(ctx.root / "build" / "bin" / "tenzir")
+    ctx.env["TENZIR_NODE_BINARY"] = str(ctx.root / "build" / "bin" / "tenzir-node")
+```
+
+This makes it possible to select local Tenzir binaries, prepare project-scoped environment variables, and collect diagnostics for failed tests without wrapping the test command in custom shell scripts. Use `--no-hooks` or `TENZIR_TEST_DISABLE_HOOKS=1` to bypass hooks when debugging.

--- a/changelog/unreleased/project-lifecycle-hooks.md
+++ b/changelog/unreleased/project-lifecycle-hooks.md
@@ -15,7 +15,7 @@ from tenzir_test import hooks
 
 @hooks.startup
 def use_local_build(ctx):
-    ctx.prepend_path(ctx.root / "build" / "bin")
+    ctx.path.insert(0, str(ctx.root / "build" / "bin"))
     ctx.env["TENZIR_BINARY"] = str(ctx.root / "build" / "bin" / "tenzir")
     ctx.env["TENZIR_NODE_BINARY"] = str(ctx.root / "build" / "bin" / "tenzir-node")
 ```

--- a/src/tenzir_test/cli.py
+++ b/src/tenzir_test/cli.py
@@ -191,6 +191,11 @@ Documentation: https://docs.tenzir.com/reference/test-framework/
     help="Run the root project alongside any selected satellites.",
 )
 @click.option(
+    "--no-hooks",
+    is_flag=True,
+    help="Disable project hook loading and invocation.",
+)
+@click.option(
     "-m",
     "--match",
     "match_patterns",
@@ -233,6 +238,7 @@ def cli(
     run_skipped: bool,
     run_skipped_reasons: tuple[str, ...],
     all_projects: bool,
+    no_hooks: bool,
 ) -> int:
     """Execute test scenarios and compare output against baselines.
 
@@ -280,6 +286,7 @@ def cli(
                 fixtures=list(fixtures),
                 debug=debug,
                 keep_tmp_dirs=keep_tmp_dirs,
+                no_hooks=no_hooks,
             )
 
         result = runtime.run_cli(
@@ -305,6 +312,7 @@ def cli(
             jobs_overridden=jobs_overridden,
             all_projects=all_projects,
             match_patterns=list(match_patterns),
+            no_hooks=no_hooks,
         )
     except runtime.HarnessError as exc:
         if exc.show_message and exc.args:

--- a/src/tenzir_test/hooks.py
+++ b/src/tenzir_test/hooks.py
@@ -275,6 +275,9 @@ class HookInvocationError(RuntimeError):
     pass
 
 
+_TEARDOWN_EVENTS: frozenset[HookEvent] = frozenset({"shutdown", "project_finish", "test_finish"})
+
+
 def invoke(
     hook_sets: Sequence[HookSet],
     event: HookEvent,
@@ -286,8 +289,11 @@ def invoke(
     debug: bool = False,
 ) -> None:
     ordered_sets = tuple(reversed(hook_sets)) if reverse else tuple(hook_sets)
+    errors: list[HookInvocationError] = []
     for hook_set in ordered_sets:
-        for func in getattr(hook_set, event):
+        funcs = tuple(getattr(hook_set, event))
+        ordered_funcs = tuple(reversed(funcs)) if reverse else funcs
+        for func in ordered_funcs:
             if debug:
                 name = getattr(func, "__qualname__", getattr(func, "__name__", repr(func)))
                 module = getattr(func, "__module__", "<unknown>")
@@ -303,4 +309,13 @@ def invoke(
                 if project_root is not None:
                     parts.append(f"in {project_root}")
                 parts.append(f"({module}): {exc}")
-                raise HookInvocationError(" ".join(parts)) from exc
+                error = HookInvocationError(" ".join(parts))
+                if event in _TEARDOWN_EVENTS:
+                    errors.append(error)
+                    continue
+                raise error from exc
+    if errors:
+        first = errors[0]
+        for error in errors[1:]:
+            first.add_note(str(error))
+        raise first

--- a/src/tenzir_test/hooks.py
+++ b/src/tenzir_test/hooks.py
@@ -5,10 +5,9 @@ from __future__ import annotations
 import contextvars
 import dataclasses
 import os
-import subprocess
-from collections.abc import Callable, MutableMapping, Sequence
+from collections.abc import Callable, Iterator, MutableMapping, Sequence
 from pathlib import Path
-from typing import Any, Literal, TypeVar, cast
+from typing import Literal, TypeVar, cast
 
 HookEvent = Literal[
     "startup",
@@ -58,6 +57,41 @@ HOOK_EVENTS: tuple[HookEvent, ...] = (
 _loading_hooks: contextvars.ContextVar[HookSet | None] = contextvars.ContextVar(
     "tenzir_test_loading_hooks", default=None
 )
+
+
+class HookEnvironment(MutableMapping[str, str]):
+    """Mutable hook environment with PATH managed through a separate list."""
+
+    def __init__(self, env: MutableMapping[str, str], path: list[str]) -> None:
+        self._env = env
+        self._path = path
+
+    def __getitem__(self, key: str) -> str:
+        if key == "PATH":
+            return os.pathsep.join(self._path)
+        return self._env[key]
+
+    def __setitem__(self, key: str, value: str) -> None:
+        if key == "PATH":
+            raise RuntimeError("modify ctx.path instead of ctx.env['PATH']")
+        self._env[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        if key == "PATH":
+            raise RuntimeError("modify ctx.path instead of ctx.env['PATH']")
+        del self._env[key]
+
+    def __iter__(self) -> Iterator[str]:
+        yielded_path = False
+        for key in self._env:
+            if key == "PATH":
+                yielded_path = True
+            yield key
+        if not yielded_path and self._path:
+            yield "PATH"
+
+    def __len__(self) -> int:
+        return len(self._env) + (0 if "PATH" in self._env or not self._path else 1)
 
 
 def _register(event: HookEvent, func: T) -> T:
@@ -153,20 +187,8 @@ class SuiteView:
 class StartupContext:
     root: Path
     env: MutableMapping[str, str]
+    path: list[str]
     debug: bool
-
-    def prepend_path(self, path: str | Path) -> None:
-        self.env["PATH"] = os.pathsep.join([str(path), self.env.get("PATH", "")])
-
-    def append_path(self, path: str | Path) -> None:
-        current = self.env.get("PATH", "")
-        self.env["PATH"] = os.pathsep.join([current, str(path)]) if current else str(path)
-
-    def check_output(self, args: Sequence[str | Path], **kwargs: Any) -> str:
-        return cast(
-            str,
-            subprocess.check_output([str(arg) for arg in args], text=True, env=self.env, **kwargs),
-        )
 
 
 @dataclasses.dataclass(frozen=True, slots=True)
@@ -186,6 +208,7 @@ class ProjectStartContext:
     previous_project: ProjectView | None
     kind: Literal["root", "satellite"]
     env: MutableMapping[str, str]
+    path: list[str]
     debug: bool
     update: bool
     coverage: bool

--- a/src/tenzir_test/hooks.py
+++ b/src/tenzir_test/hooks.py
@@ -1,0 +1,283 @@
+"""Project hook registration and invocation for tenzir-test."""
+
+from __future__ import annotations
+
+import contextvars
+import dataclasses
+import os
+import subprocess
+from collections.abc import Callable, MutableMapping, Sequence
+from pathlib import Path
+from typing import Any, Literal, TypeVar, cast
+
+HookEvent = Literal[
+    "startup",
+    "shutdown",
+    "project_start",
+    "project_finish",
+    "test_start",
+    "test_finish",
+    "test_failure",
+]
+
+T = TypeVar("T")
+
+
+@dataclasses.dataclass(slots=True)
+class HookSet:
+    startup: list[Callable[["StartupContext"], None]] = dataclasses.field(default_factory=list)
+    shutdown: list[Callable[["ShutdownContext"], None]] = dataclasses.field(default_factory=list)
+    project_start: list[Callable[["ProjectStartContext"], None]] = dataclasses.field(
+        default_factory=list
+    )
+    project_finish: list[Callable[["ProjectFinishContext"], None]] = dataclasses.field(
+        default_factory=list
+    )
+    test_start: list[Callable[["TestStartContext"], None]] = dataclasses.field(default_factory=list)
+    test_finish: list[Callable[["TestFinishContext"], None]] = dataclasses.field(
+        default_factory=list
+    )
+    test_failure: list[Callable[["TestFailureContext"], None]] = dataclasses.field(
+        default_factory=list
+    )
+
+    def is_empty(self) -> bool:
+        return not any(getattr(self, event) for event in HOOK_EVENTS)
+
+
+HOOK_EVENTS: tuple[HookEvent, ...] = (
+    "startup",
+    "shutdown",
+    "project_start",
+    "project_finish",
+    "test_start",
+    "test_finish",
+    "test_failure",
+)
+
+_loading_hooks: contextvars.ContextVar[HookSet | None] = contextvars.ContextVar(
+    "tenzir_test_loading_hooks", default=None
+)
+
+
+def _register(event: HookEvent, func: T) -> T:
+    current = _loading_hooks.get()
+    if current is None:
+        raise RuntimeError(f"@hooks.{event} can only be used while tenzir-test loads project hooks")
+    getattr(current, event).append(func)
+    return func
+
+
+def startup(func: Callable[["StartupContext"], None]) -> Callable[["StartupContext"], None]:
+    return _register("startup", func)
+
+
+def shutdown(func: Callable[["ShutdownContext"], None]) -> Callable[["ShutdownContext"], None]:
+    return _register("shutdown", func)
+
+
+def project_start(
+    func: Callable[["ProjectStartContext"], None],
+) -> Callable[["ProjectStartContext"], None]:
+    return _register("project_start", func)
+
+
+def project_finish(
+    func: Callable[["ProjectFinishContext"], None],
+) -> Callable[["ProjectFinishContext"], None]:
+    return _register("project_finish", func)
+
+
+def test_start(func: Callable[["TestStartContext"], None]) -> Callable[["TestStartContext"], None]:
+    return _register("test_start", func)
+
+
+def test_finish(
+    func: Callable[["TestFinishContext"], None],
+) -> Callable[["TestFinishContext"], None]:
+    return _register("test_finish", func)
+
+
+def test_failure(
+    func: Callable[["TestFailureContext"], None],
+) -> Callable[["TestFailureContext"], None]:
+    return _register("test_failure", func)
+
+
+class loading(HookSet):
+    """Context manager that makes decorators register in this hook set."""
+
+    _token: contextvars.Token[HookSet | None]
+
+    def __enter__(self) -> HookSet:
+        self._token = _loading_hooks.set(self)
+        return self
+
+    def __exit__(self, exc_type: object, exc: object, tb: object) -> None:
+        _loading_hooks.reset(self._token)
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class SummaryView:
+    failed: int
+    total: int
+    skipped: int
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class ProjectView:
+    root: Path
+    kind: Literal["root", "satellite"]
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class ProjectResultView:
+    project: ProjectView
+    summary: SummaryView
+    queue_size: int
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class FixtureSpecView:
+    name: str
+    options: object | None = None
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class SuiteView:
+    name: str
+    directory: Path
+
+
+@dataclasses.dataclass(slots=True)
+class StartupContext:
+    root: Path
+    env: MutableMapping[str, str]
+    debug: bool
+
+    def prepend_path(self, path: str | Path) -> None:
+        self.env["PATH"] = os.pathsep.join([str(path), self.env.get("PATH", "")])
+
+    def append_path(self, path: str | Path) -> None:
+        current = self.env.get("PATH", "")
+        self.env["PATH"] = os.pathsep.join([current, str(path)]) if current else str(path)
+
+    def check_output(self, args: Sequence[str | Path], **kwargs: Any) -> str:
+        return cast(
+            str,
+            subprocess.check_output([str(arg) for arg in args], text=True, env=self.env, **kwargs),
+        )
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class ShutdownContext:
+    root: Path
+    exit_code: int
+    interrupted: bool
+    summary: SummaryView
+    project_results: tuple[ProjectResultView, ...]
+    debug: bool
+
+
+@dataclasses.dataclass(slots=True)
+class ProjectStartContext:
+    root: Path
+    project: ProjectView
+    previous_project: ProjectView | None
+    kind: Literal["root", "satellite"]
+    env: MutableMapping[str, str]
+    debug: bool
+    update: bool
+    coverage: bool
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class ProjectFinishContext:
+    root: Path
+    project: ProjectView
+    next_project: ProjectView | None
+    kind: Literal["root", "satellite"]
+    summary: SummaryView
+    interrupted: bool
+    debug: bool
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class TestStartContext:
+    root: Path
+    project: ProjectView
+    test: Path
+    runner: str
+    fixtures: tuple[FixtureSpecView, ...]
+    suite: SuiteView | None
+    update: bool
+    coverage: bool
+    attempt_limit: int
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class TestFinishContext:
+    root: Path
+    project: ProjectView
+    test: Path
+    runner: str
+    outcome: Literal["passed", "failed", "skipped"]
+    reason: str | None
+    attempts: int
+    duration: float
+    fixtures: tuple[FixtureSpecView, ...]
+    suite: SuiteView | None
+    tmp_dir: Path | None
+    update: bool
+    coverage: bool
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class TestFailureContext:
+    root: Path
+    project: ProjectView
+    test: Path
+    runner: str
+    reason: str | None
+    attempts: int
+    duration: float
+    fixtures: tuple[FixtureSpecView, ...]
+    suite: SuiteView | None
+    tmp_dir: Path | None
+    update: bool
+    coverage: bool
+
+
+class HookInvocationError(RuntimeError):
+    pass
+
+
+def invoke(
+    hook_sets: Sequence[HookSet],
+    event: HookEvent,
+    context: object,
+    *,
+    reverse: bool = False,
+    project_root: Path | None = None,
+    test_path: Path | None = None,
+    debug: bool = False,
+) -> None:
+    ordered_sets = tuple(reversed(hook_sets)) if reverse else tuple(hook_sets)
+    for hook_set in ordered_sets:
+        for func in getattr(hook_set, event):
+            if debug:
+                name = getattr(func, "__qualname__", getattr(func, "__name__", repr(func)))
+                module = getattr(func, "__module__", "<unknown>")
+                print(f"debug: invoking hook {event} {module}.{name}")
+            try:
+                cast(Callable[[object], None], func)(context)
+            except Exception as exc:
+                name = getattr(func, "__qualname__", getattr(func, "__name__", repr(func)))
+                module = getattr(func, "__module__", "<unknown>")
+                parts = [f"hook {event} {name} failed"]
+                if test_path is not None:
+                    parts.append(f"for {test_path}")
+                if project_root is not None:
+                    parts.append(f"in {project_root}")
+                parts.append(f"({module}): {exc}")
+                raise HookInvocationError(" ".join(parts)) from exc

--- a/src/tenzir_test/hooks.py
+++ b/src/tenzir_test/hooks.py
@@ -304,7 +304,7 @@ def invoke(
                 print(f"debug: invoking hook {event} {module}.{name}")
             try:
                 cast(Callable[[object], None], func)(context)
-            except Exception as exc:
+            except BaseException as exc:
                 name = getattr(func, "__qualname__", getattr(func, "__name__", repr(func)))
                 module = getattr(func, "__module__", "<unknown>")
                 parts = [f"hook {event} {name} failed"]

--- a/src/tenzir_test/hooks.py
+++ b/src/tenzir_test/hooks.py
@@ -93,6 +93,10 @@ class HookEnvironment(MutableMapping[str, str]):
     def __len__(self) -> int:
         return len(self._env) + (0 if "PATH" in self._env or not self._path else 1)
 
+    def clear(self) -> None:
+        self._env.clear()
+        self._path.clear()
+
 
 def _register(event: HookEvent, func: T) -> T:
     current = _loading_hooks.get()

--- a/src/tenzir_test/run.py
+++ b/src/tenzir_test/run.py
@@ -5724,6 +5724,8 @@ def run_fixture_mode_cli(
     _HOOKS_DISABLED = _hooks_disabled(no_hooks)
     root_path = Path(root or os.environ.get("TENZIR_TEST_ROOT") or Path.cwd()).resolve()
     root_hooks = hooks_impl.HookSet()
+    startup_succeeded = False
+    shutdown_invoked = False
     try:
         if not _HOOKS_DISABLED:
             try:
@@ -5740,6 +5742,7 @@ def run_fixture_mode_cli(
             )
             os.environ.clear()
             os.environ.update(env)
+            startup_succeeded = True
     except hooks_impl.HookInvocationError as exc:
         raise HarnessError(f"error: {exc}") from exc
 
@@ -5794,25 +5797,15 @@ def run_fixture_mode_cli(
             fixture_options=fixture_options,
         )
     )
-    try:
-        with fixtures_impl.activate(fixture_specs) as fixture_env:
-            env.update(fixture_env)
-            _apply_fixture_env(env, fixture_specs)
-            _print_fixture_env_lines(fixture_env)
-            _wait_for_fixture_shutdown()
-    except fixtures_impl.FixtureUnavailable as exc:
-        _raise_fixture_unavailable_harness_error(exc)
-    finally:
-        fixtures_impl.pop_context(context_token)
-        cleanup_test_tmp_dir(env.get(TEST_TMP_ENV_VAR))
 
-    try:
+    def _invoke_fixture_shutdown(exit_code: int) -> None:
+        nonlocal shutdown_invoked
         _invoke_hooks(
             (root_hooks,),
             "shutdown",
             hooks_impl.ShutdownContext(
                 root=settings.root,
-                exit_code=0,
+                exit_code=exit_code,
                 interrupted=False,
                 summary=hooks_impl.SummaryView(failed=0, total=0, skipped=0),
                 project_results=tuple(),
@@ -5822,6 +5815,27 @@ def run_fixture_mode_cli(
             project_root=settings.root,
             debug=debug_enabled,
         )
+        shutdown_invoked = True
+
+    try:
+        with fixtures_impl.activate(fixture_specs) as fixture_env:
+            env.update(fixture_env)
+            _apply_fixture_env(env, fixture_specs)
+            _print_fixture_env_lines(fixture_env)
+            _wait_for_fixture_shutdown()
+    except fixtures_impl.FixtureUnavailable as exc:
+        if startup_succeeded and not shutdown_invoked:
+            try:
+                _invoke_fixture_shutdown(1)
+            except hooks_impl.HookInvocationError as shutdown_exc:
+                raise HarnessError(f"error: {shutdown_exc}") from exc
+        _raise_fixture_unavailable_harness_error(exc)
+    finally:
+        fixtures_impl.pop_context(context_token)
+        cleanup_test_tmp_dir(env.get(TEST_TMP_ENV_VAR))
+
+    try:
+        _invoke_fixture_shutdown(0)
     except hooks_impl.HookInvocationError as exc:
         raise HarnessError(f"error: {exc}") from exc
 
@@ -5873,6 +5887,13 @@ def run_cli(
     """
     from tenzir_test.engine import state as engine_state
 
+    debug_enabled = bool(debug or _default_debug_logging)
+    root_path = Path(root or os.environ.get("TENZIR_TEST_ROOT") or Path.cwd()).resolve()
+    root_hooks = hooks_impl.HookSet()
+    settings: Settings | None = None
+    startup_succeeded = False
+    shutdown_invoked = False
+
     try:
         debug_enabled = bool(debug or _default_debug_logging)
         _configure_runtime_logging(debug_enabled=debug_enabled)
@@ -5901,7 +5922,6 @@ def run_cli(
 
         global _HOOKS_DISABLED
         _HOOKS_DISABLED = _hooks_disabled(no_hooks)
-        root_path = Path(root or os.environ.get("TENZIR_TEST_ROOT") or Path.cwd()).resolve()
         try:
             root_hooks = hooks_impl.HookSet() if _HOOKS_DISABLED else _load_project_hooks(root_path)
         except RuntimeError as exc:
@@ -5917,6 +5937,7 @@ def run_cli(
             )
             os.environ.clear()
             os.environ.update(env)
+            startup_succeeded = True
 
         settings = discover_settings(root=root_path)
         apply_settings(settings)
@@ -6027,6 +6048,7 @@ def run_cli(
                 )
                 project_view = _project_view(selection)
                 project_env = os.environ.copy()
+                project_env["TENZIR_EXEC__DUMP_DIAGNOSTICS"] = "true"
                 next_selection = next(
                     (
                         candidate
@@ -6056,152 +6078,314 @@ def run_cli(
                 _CURRENT_PROJECT_VIEW = project_view
                 _CURRENT_HOOK_CHAIN = hook_chain
 
-                tests_to_run = selection.selectors if not selection.run_all else [selection.root]
-
-                if purge:
-                    project_summary = Summary()
-                    _invoke_hooks(
-                        hook_chain,
-                        "project_finish",
-                        hooks_impl.ProjectFinishContext(
-                            root=settings.root,
-                            project=project_view,
-                            next_project=_project_view(next_selection) if next_selection else None,
-                            kind=selection.kind,
-                            summary=_summary_view(project_summary),
-                            interrupted=interrupted or interrupt_requested(),
-                            debug=debug_enabled,
-                        ),
-                        reverse=True,
-                        project_root=selection.root,
-                        debug=debug_enabled,
+                project_finish_pending = True
+                project_summary = Summary()
+                try:
+                    tests_to_run = (
+                        selection.selectors if not selection.run_all else [selection.root]
                     )
-                    previous_project_view = project_view
-                    _CURRENT_PROJECT_ENV = None
-                    _CURRENT_PROJECT_VIEW = None
-                    _CURRENT_HOOK_CHAIN = tuple()
-                    continue
 
-                collected_paths: set[Path] = set()
-                for test in tests_to_run:
-                    if test.resolve() == selection.root.resolve():
-                        all_tests = []
-                        for tests_dir in _iter_project_test_directories(selection.root):
-                            all_tests.extend(list(collect_all_tests(tests_dir)))
-                        for test_path in all_tests:
-                            collected_paths.add(test_path.resolve())
+                    if purge:
+                        project_summary = Summary()
+                        _invoke_hooks(
+                            hook_chain,
+                            "project_finish",
+                            hooks_impl.ProjectFinishContext(
+                                root=settings.root,
+                                project=project_view,
+                                next_project=_project_view(next_selection)
+                                if next_selection
+                                else None,
+                                kind=selection.kind,
+                                summary=_summary_view(project_summary),
+                                interrupted=interrupted or interrupt_requested(),
+                                debug=debug_enabled,
+                            ),
+                            reverse=True,
+                            project_root=selection.root,
+                            debug=debug_enabled,
+                        )
+                        project_finish_pending = False
+                        previous_project_view = project_view
+                        _CURRENT_PROJECT_ENV = None
+                        _CURRENT_PROJECT_VIEW = None
+                        _CURRENT_HOOK_CHAIN = tuple()
                         continue
 
-                    resolved = test.resolve()
-                    if not resolved.exists():
-                        raise HarnessError(f"error: test path `{test}` does not exist")
-
-                    if resolved.is_dir():
-                        if _is_inputs_path(resolved):
+                    collected_paths: set[Path] = set()
+                    for test in tests_to_run:
+                        if test.resolve() == selection.root.resolve():
+                            all_tests = []
+                            for tests_dir in _iter_project_test_directories(selection.root):
+                                all_tests.extend(list(collect_all_tests(tests_dir)))
+                            for test_path in all_tests:
+                                collected_paths.add(test_path.resolve())
                             continue
-                        tql_files = list(collect_all_tests(resolved))
-                        if not tql_files:
-                            raise HarnessError(
-                                f"error: no {_allowed_extensions} files found in {resolved}"
-                            )
-                        for file_path in tql_files:
-                            suite_info = _resolve_suite_for_test(file_path)
-                            if suite_info is None:
+
+                        resolved = test.resolve()
+                        if not resolved.exists():
+                            raise HarnessError(f"error: test path `{test}` does not exist")
+
+                        if resolved.is_dir():
+                            if _is_inputs_path(resolved):
                                 continue
-                            suite_dir = suite_info.directory
-                            if resolved == suite_dir:
-                                continue
-                            if _path_is_within(resolved, suite_dir):
-                                rel_target = _relativize_path(resolved)
-                                rel_suite = _relativize_path(suite_dir)
-                                detail = (
-                                    f"cannot select {rel_target} directly because it is inside the suite "
-                                    f"'{suite_info.name}' defined in {rel_suite / _CONFIG_FILE_NAME}."
+                            tql_files = list(collect_all_tests(resolved))
+                            if not tql_files:
+                                raise HarnessError(
+                                    f"error: no {_allowed_extensions} files found in {resolved}"
                                 )
-                                print(f"{CROSS} {detail}", file=sys.stderr)
+                            for file_path in tql_files:
+                                suite_info = _resolve_suite_for_test(file_path)
+                                if suite_info is None:
+                                    continue
+                                suite_dir = suite_info.directory
+                                if resolved == suite_dir:
+                                    continue
+                                if _path_is_within(resolved, suite_dir):
+                                    rel_target = _relativize_path(resolved)
+                                    rel_suite = _relativize_path(suite_dir)
+                                    detail = (
+                                        f"cannot select {rel_target} directly because it is inside the suite "
+                                        f"'{suite_info.name}' defined in {rel_suite / _CONFIG_FILE_NAME}."
+                                    )
+                                    print(f"{CROSS} {detail}", file=sys.stderr)
+                                    print(
+                                        f"{INFO} select the suite directory instead",
+                                        file=sys.stderr,
+                                    )
+                                    raise HarnessError(
+                                        f"invalid partial suite selection at {rel_target}",
+                                        show_message=False,
+                                    )
+                            for file_path in tql_files:
+                                collected_paths.add(file_path.resolve())
+                        elif resolved.is_file():
+                            if _is_inputs_path(resolved):
+                                continue
+                            if resolved.suffix[1:] in _allowed_extensions:
+                                suite_info = _resolve_suite_for_test(resolved)
+                                if suite_info is not None and _path_is_within(
+                                    resolved, suite_info.directory
+                                ):
+                                    rel_file = _relativize_path(resolved)
+                                    rel_suite = _relativize_path(suite_info.directory)
+                                    detail = (
+                                        f"cannot select {rel_file} directly because it belongs to the suite "
+                                        f"'{suite_info.name}' defined in {rel_suite / _CONFIG_FILE_NAME}."
+                                    )
+                                    print(f"{CROSS} {detail}", file=sys.stderr)
+                                    print(
+                                        f"{INFO} select the suite directory instead",
+                                        file=sys.stderr,
+                                    )
+                                    raise HarnessError(
+                                        f"invalid suite selection for {rel_file}",
+                                        show_message=False,
+                                    )
+                                collected_paths.add(resolved.resolve())
+                            else:
+                                raise HarnessError(
+                                    f"error: unsupported file type {resolved.suffix} for {resolved} - only {_allowed_extensions} files are supported"
+                                )
+                        else:
+                            raise HarnessError(f"error: `{test}` is neither a file nor a directory")
+
+                    active_patterns = [p.strip() for p in match_patterns if p and p.strip()]
+                    if active_patterns:
+                        # Filter collected tests to those matching any
+                        # pattern.  This acts as an intersection when path
+                        # args were given (since collected_paths was
+                        # pre-populated above), or filters all discovered
+                        # tests when no paths were specified.
+                        collected_paths = _filter_paths_by_patterns(
+                            collected_paths,
+                            active_patterns,
+                            project_root=selection.root,
+                        )
+                        collected_paths = _expand_suites(collected_paths)
+                        if not collected_paths:
+                            pattern_list = ", ".join(repr(p) for p in active_patterns)
+                            if not selection.run_all:
                                 print(
-                                    f"{INFO} select the suite directory instead",
-                                    file=sys.stderr,
+                                    f"{INFO} no tests matched pattern(s) {pattern_list}"
+                                    f" within the selected paths"
                                 )
-                                raise HarnessError(
-                                    f"invalid partial suite selection at {rel_target}",
-                                    show_message=False,
-                                )
-                        for file_path in tql_files:
-                            collected_paths.add(file_path.resolve())
-                    elif resolved.is_file():
-                        if _is_inputs_path(resolved):
-                            continue
-                        if resolved.suffix[1:] in _allowed_extensions:
-                            suite_info = _resolve_suite_for_test(resolved)
-                            if suite_info is not None and _path_is_within(
-                                resolved, suite_info.directory
-                            ):
-                                rel_file = _relativize_path(resolved)
-                                rel_suite = _relativize_path(suite_info.directory)
-                                detail = (
-                                    f"cannot select {rel_file} directly because it belongs to the suite "
-                                    f"'{suite_info.name}' defined in {rel_suite / _CONFIG_FILE_NAME}."
-                                )
-                                print(f"{CROSS} {detail}", file=sys.stderr)
-                                print(f"{INFO} select the suite directory instead", file=sys.stderr)
-                                raise HarnessError(
-                                    f"invalid suite selection for {rel_file}",
-                                    show_message=False,
-                                )
-                            collected_paths.add(resolved.resolve())
-                        else:
-                            raise HarnessError(
-                                f"error: unsupported file type {resolved.suffix} for {resolved} - only {_allowed_extensions} files are supported"
-                            )
-                    else:
-                        raise HarnessError(f"error: `{test}` is neither a file nor a directory")
+                            else:
+                                print(f"{INFO} no tests matched pattern(s): {pattern_list}")
 
-                active_patterns = [p.strip() for p in match_patterns if p and p.strip()]
-                if active_patterns:
-                    # Filter collected tests to those matching any
-                    # pattern.  This acts as an intersection when path
-                    # args were given (since collected_paths was
-                    # pre-populated above), or filters all discovered
-                    # tests when no paths were specified.
-                    collected_paths = _filter_paths_by_patterns(
-                        collected_paths,
-                        active_patterns,
-                        project_root=selection.root,
+                    if interrupt_requested():
+                        break
+
+                    queue = _build_queue_from_paths(collected_paths, coverage=coverage)
+                    queue.sort(key=_queue_sort_key, reverse=True)
+                    _validate_parallel_suite_min_jobs(queue, jobs=jobs)
+                    _warn_parallel_suite_oversubscription(queue, jobs=jobs)
+                    project_queue_size = _count_queue_tests(queue)
+                    project_summary = Summary()
+                    job_count, enabled_flags, verb = _summarize_harness_configuration(
+                        jobs=jobs,
+                        update=update,
+                        coverage=coverage,
+                        debug=debug_enabled,
+                        show_summary=show_summary,
+                        runner_summary=runner_summary,
+                        fixture_summary=fixture_summary,
+                        passthrough=passthrough_mode,
+                        run_skipped_selector=run_skipped_selector,
                     )
-                    collected_paths = _expand_suites(collected_paths)
-                    if not collected_paths:
-                        pattern_list = ", ".join(repr(p) for p in active_patterns)
-                        if not selection.run_all:
-                            print(
-                                f"{INFO} no tests matched pattern(s) {pattern_list}"
-                                f" within the selected paths"
+
+                    if not project_queue_size:
+                        overall_queue_count += project_queue_size
+                        executed_projects.append(selection)
+                        project_results.append(
+                            ProjectResult(
+                                selection=selection,
+                                summary=project_summary,
+                                queue_size=project_queue_size,
                             )
-                        else:
-                            print(f"{INFO} no tests matched pattern(s): {pattern_list}")
+                        )
+                        _invoke_hooks(
+                            hook_chain,
+                            "project_finish",
+                            hooks_impl.ProjectFinishContext(
+                                root=settings.root,
+                                project=project_view,
+                                next_project=_project_view(next_selection)
+                                if next_selection
+                                else None,
+                                kind=selection.kind,
+                                summary=_summary_view(project_summary),
+                                interrupted=interrupted or interrupt_requested(),
+                                debug=debug_enabled,
+                            ),
+                            reverse=True,
+                            project_root=selection.root,
+                            debug=debug_enabled,
+                        )
+                        project_finish_pending = False
+                        previous_project_view = project_view
+                        _CURRENT_PROJECT_ENV = None
+                        _CURRENT_PROJECT_VIEW = None
+                        _CURRENT_HOOK_CHAIN = tuple()
+                        continue
 
-                if interrupt_requested():
-                    break
+                    os.environ["TENZIR_EXEC__DUMP_DIAGNOSTICS"] = "true"
+                    if not TENZIR_BINARY:
+                        raise HarnessError(
+                            f"error: could not find TENZIR_BINARY executable `{TENZIR_BINARY}`"
+                        )
+                    try:
+                        tenzir_version = get_version()
+                    except FileNotFoundError:
+                        raise HarnessError(
+                            f"error: could not find TENZIR_BINARY executable `{TENZIR_BINARY}`"
+                        )
+                    except subprocess.CalledProcessError as exc:
+                        if _is_interrupt_exit(exc.returncode) or interrupt_requested():
+                            _request_interrupt()
+                            interrupted = True
+                            break
+                        raise
 
-                queue = _build_queue_from_paths(collected_paths, coverage=coverage)
-                queue.sort(key=_queue_sort_key, reverse=True)
-                _validate_parallel_suite_min_jobs(queue, jobs=jobs)
-                _warn_parallel_suite_oversubscription(queue, jobs=jobs)
-                project_queue_size = _count_queue_tests(queue)
-                project_summary = Summary()
-                job_count, enabled_flags, verb = _summarize_harness_configuration(
-                    jobs=jobs,
-                    update=update,
-                    coverage=coverage,
-                    debug=debug_enabled,
-                    show_summary=show_summary,
-                    runner_summary=runner_summary,
-                    fixture_summary=fixture_summary,
-                    passthrough=passthrough_mode,
-                    run_skipped_selector=run_skipped_selector,
-                )
+                    runner_versions = _collect_runner_versions(queue, tenzir_version=tenzir_version)
+                    runner_breakdown = _runner_breakdown(
+                        queue,
+                        tenzir_version=tenzir_version,
+                        runner_versions=runner_versions,
+                    )
 
-                if not project_queue_size:
+                    _print_project_start(
+                        selection=selection,
+                        display_base=display_base,
+                        queue_size=project_queue_size,
+                        job_count=job_count,
+                        enabled_flags=enabled_flags,
+                        verb=verb,
+                    )
+                    count_width = max(
+                        (len(str(count)) for _, count, _ in runner_breakdown), default=1
+                    )
+                    for name, count, version in runner_breakdown:
+                        version_segment = f" (v{version})" if version else ""
+                        print(f"{INFO}   {count:>{count_width}}× {name}{version_segment}")
+                    printed_projects += 1
+
+                    test_slots = threading.BoundedSemaphore(max(1, jobs))
+                    slot_lock = threading.Lock()
+                    queue_lock = threading.Lock()
+                    suite_queue_state = SuiteQueueState(
+                        pending_items=_count_suite_queue_items(queue)
+                    )
+                    workers = [
+                        Worker(
+                            queue,
+                            update=update,
+                            coverage=coverage,
+                            runner_versions=runner_versions,
+                            debug=debug_enabled,
+                            run_skipped_selector=run_skipped_selector,
+                            jobs=jobs,
+                            test_slots=test_slots,
+                            slot_lock=slot_lock,
+                            queue_lock=queue_lock,
+                            suite_queue_state=suite_queue_state,
+                            hook_chain=hook_chain,
+                            project_view=project_view,
+                        )
+                        for _ in range(jobs)
+                    ]
+                    for worker in workers:
+                        worker.start()
+                    skip_filter_matches = 0
+                    try:
+                        for worker in workers:
+                            project_summary += worker.join()
+                            skip_filter_matches += worker.run_skipped_match_count
+                    except KeyboardInterrupt:  # pragma: no cover - defensive guard
+                        _request_interrupt()
+                        for worker in workers:
+                            worker.join()
+                        interrupted = True
+                        break
+                    except fixtures_impl.FixtureUnavailable as exc:
+                        _raise_fixture_unavailable_harness_error(exc)
+                    except Exception as exc:
+                        if not (_exception_is_interrupt(exc) or interrupt_requested()):
+                            raise
+                        _request_interrupt()
+                        for remaining_worker in workers:
+                            try:
+                                remaining_worker.join()
+                            except Exception as join_exc:
+                                if not (_exception_is_interrupt(join_exc) or interrupt_requested()):
+                                    raise
+                        interrupted = True
+                        break
+                    if run_skipped_selector.has_reason_filters and skip_filter_matches == 0:
+                        print(f"{INFO} no skipped tests matched run-skipped filters")
+
+                    _print_compact_summary(project_summary)
+                    summary_enabled = show_summary or runner_summary or fixture_summary
+                    if summary_enabled:
+                        if is_verbose_output():
+                            _print_detailed_summary(project_summary)
+                        _print_ascii_summary(
+                            project_summary,
+                            include_runner=runner_summary,
+                            include_fixture=fixture_summary,
+                        )
+
+                    if coverage:
+                        coverage_dir = os.environ.get(
+                            "CMAKE_COVERAGE_OUTPUT_DIRECTORY", os.path.join(os.getcwd(), "coverage")
+                        )
+                        source_dir = (
+                            str(coverage_source_dir) if coverage_source_dir else os.getcwd()
+                        )
+                        print(f"{INFO} Code coverage data collected in {coverage_dir}")
+                        print(f"{INFO} Source directory for coverage mapping: {source_dir}")
+
+                    overall_summary += project_summary
                     overall_queue_count += project_queue_size
                     executed_projects.append(selection)
                     project_results.append(
@@ -6227,161 +6411,45 @@ def run_cli(
                         project_root=selection.root,
                         debug=debug_enabled,
                     )
+                    project_finish_pending = False
                     previous_project_view = project_view
                     _CURRENT_PROJECT_ENV = None
                     _CURRENT_PROJECT_VIEW = None
                     _CURRENT_HOOK_CHAIN = tuple()
-                    continue
 
-                os.environ["TENZIR_EXEC__DUMP_DIAGNOSTICS"] = "true"
-                if not TENZIR_BINARY:
-                    raise HarnessError(
-                        f"error: could not find TENZIR_BINARY executable `{TENZIR_BINARY}`"
-                    )
-                try:
-                    tenzir_version = get_version()
-                except FileNotFoundError:
-                    raise HarnessError(
-                        f"error: could not find TENZIR_BINARY executable `{TENZIR_BINARY}`"
-                    )
-                except subprocess.CalledProcessError as exc:
-                    if _is_interrupt_exit(exc.returncode) or interrupt_requested():
-                        _request_interrupt()
-                        interrupted = True
+                    if interrupt_requested():
                         break
-                    raise
 
-                runner_versions = _collect_runner_versions(queue, tenzir_version=tenzir_version)
-                runner_breakdown = _runner_breakdown(
-                    queue,
-                    tenzir_version=tenzir_version,
-                    runner_versions=runner_versions,
-                )
-
-                _print_project_start(
-                    selection=selection,
-                    display_base=display_base,
-                    queue_size=project_queue_size,
-                    job_count=job_count,
-                    enabled_flags=enabled_flags,
-                    verb=verb,
-                )
-                count_width = max((len(str(count)) for _, count, _ in runner_breakdown), default=1)
-                for name, count, version in runner_breakdown:
-                    version_segment = f" (v{version})" if version else ""
-                    print(f"{INFO}   {count:>{count_width}}× {name}{version_segment}")
-                printed_projects += 1
-
-                test_slots = threading.BoundedSemaphore(max(1, jobs))
-                slot_lock = threading.Lock()
-                queue_lock = threading.Lock()
-                suite_queue_state = SuiteQueueState(pending_items=_count_suite_queue_items(queue))
-                workers = [
-                    Worker(
-                        queue,
-                        update=update,
-                        coverage=coverage,
-                        runner_versions=runner_versions,
-                        debug=debug_enabled,
-                        run_skipped_selector=run_skipped_selector,
-                        jobs=jobs,
-                        test_slots=test_slots,
-                        slot_lock=slot_lock,
-                        queue_lock=queue_lock,
-                        suite_queue_state=suite_queue_state,
-                        hook_chain=hook_chain,
-                        project_view=project_view,
-                    )
-                    for _ in range(jobs)
-                ]
-                for worker in workers:
-                    worker.start()
-                skip_filter_matches = 0
-                try:
-                    for worker in workers:
-                        project_summary += worker.join()
-                        skip_filter_matches += worker.run_skipped_match_count
-                except KeyboardInterrupt:  # pragma: no cover - defensive guard
-                    _request_interrupt()
-                    for worker in workers:
-                        worker.join()
-                    interrupted = True
-                    break
-                except fixtures_impl.FixtureUnavailable as exc:
-                    _raise_fixture_unavailable_harness_error(exc)
-                except Exception as exc:
-                    if not (_exception_is_interrupt(exc) or interrupt_requested()):
-                        raise
-                    _request_interrupt()
-                    for remaining_worker in workers:
-                        try:
-                            remaining_worker.join()
-                        except Exception as join_exc:
-                            if not (_exception_is_interrupt(join_exc) or interrupt_requested()):
-                                raise
-                    interrupted = True
-                    break
-                if run_skipped_selector.has_reason_filters and skip_filter_matches == 0:
-                    print(f"{INFO} no skipped tests matched run-skipped filters")
-
-                _print_compact_summary(project_summary)
-                summary_enabled = show_summary or runner_summary or fixture_summary
-                if summary_enabled:
-                    if is_verbose_output():
-                        _print_detailed_summary(project_summary)
-                    _print_ascii_summary(
-                        project_summary,
-                        include_runner=runner_summary,
-                        include_fixture=fixture_summary,
-                    )
-
-                if coverage:
-                    coverage_dir = os.environ.get(
-                        "CMAKE_COVERAGE_OUTPUT_DIRECTORY", os.path.join(os.getcwd(), "coverage")
-                    )
-                    source_dir = str(coverage_source_dir) if coverage_source_dir else os.getcwd()
-                    print(f"{INFO} Code coverage data collected in {coverage_dir}")
-                    print(f"{INFO} Source directory for coverage mapping: {source_dir}")
-
-                overall_summary += project_summary
-                overall_queue_count += project_queue_size
-                executed_projects.append(selection)
-                project_results.append(
-                    ProjectResult(
-                        selection=selection,
-                        summary=project_summary,
-                        queue_size=project_queue_size,
-                    )
-                )
-                _invoke_hooks(
-                    hook_chain,
-                    "project_finish",
-                    hooks_impl.ProjectFinishContext(
-                        root=settings.root,
-                        project=project_view,
-                        next_project=_project_view(next_selection) if next_selection else None,
-                        kind=selection.kind,
-                        summary=_summary_view(project_summary),
-                        interrupted=interrupted or interrupt_requested(),
-                        debug=debug_enabled,
-                    ),
-                    reverse=True,
-                    project_root=selection.root,
-                    debug=debug_enabled,
-                )
-                previous_project_view = project_view
-                _CURRENT_PROJECT_ENV = None
-                _CURRENT_PROJECT_VIEW = None
-                _CURRENT_HOOK_CHAIN = tuple()
-
-                if interrupt_requested():
-                    break
-
+                finally:
+                    if project_finish_pending:
+                        _invoke_hooks(
+                            hook_chain,
+                            "project_finish",
+                            hooks_impl.ProjectFinishContext(
+                                root=settings.root,
+                                project=project_view,
+                                next_project=_project_view(next_selection)
+                                if next_selection
+                                else None,
+                                kind=selection.kind,
+                                summary=_summary_view(project_summary),
+                                interrupted=interrupted or interrupt_requested(),
+                                debug=debug_enabled,
+                            ),
+                            reverse=True,
+                            project_root=selection.root,
+                            debug=debug_enabled,
+                        )
+                    previous_project_view = project_view
+                    _CURRENT_PROJECT_ENV = None
+                    _CURRENT_PROJECT_VIEW = None
+                    _CURRENT_HOOK_CHAIN = tuple()
             # Restore root project context for subsequent operations.
             _set_project_root(settings.root)
             engine_state.refresh()
 
             def _finish_result(result: ExecutionResult) -> ExecutionResult:
+                nonlocal shutdown_invoked
                 _invoke_hooks(
                     (root_hooks,),
                     "shutdown",
@@ -6399,6 +6467,7 @@ def run_cli(
                     project_root=settings.root,
                     debug=debug_enabled,
                 )
+                shutdown_invoked = True
                 return result
 
             interrupted = interrupted or interrupt_requested()
@@ -6452,8 +6521,32 @@ def run_cli(
                 )
             )
 
-    except hooks_impl.HookInvocationError as exc:
-        raise HarnessError(f"error: {exc}") from exc
+    except Exception as exc:
+        if startup_succeeded and not shutdown_invoked:
+            shutdown_root = settings.root if settings is not None else root_path
+            try:
+                _invoke_hooks(
+                    (root_hooks,),
+                    "shutdown",
+                    hooks_impl.ShutdownContext(
+                        root=shutdown_root,
+                        exit_code=130 if interrupt_requested() else 1,
+                        interrupted=interrupt_requested(),
+                        summary=hooks_impl.SummaryView(failed=0, total=0, skipped=0),
+                        project_results=tuple(),
+                        debug=debug_enabled,
+                    ),
+                    reverse=True,
+                    project_root=shutdown_root,
+                    debug=debug_enabled,
+                )
+            except hooks_impl.HookInvocationError as shutdown_exc:
+                if isinstance(exc, hooks_impl.HookInvocationError):
+                    raise HarnessError(f"error: {exc}; additionally, {shutdown_exc}") from exc
+                raise HarnessError(f"error: {shutdown_exc}") from exc
+        if isinstance(exc, hooks_impl.HookInvocationError):
+            raise HarnessError(f"error: {exc}") from exc
+        raise
     finally:
         _cleanup_all_tmp_dirs()
         _CURRENT_PROJECT_ENV = None

--- a/src/tenzir_test/run.py
+++ b/src/tenzir_test/run.py
@@ -25,7 +25,7 @@ import tempfile
 import threading
 import time
 import typing
-from collections.abc import Iterable, Iterator, Mapping, Sequence
+from collections.abc import Iterable, Iterator, Mapping, MutableMapping, Sequence
 from pathlib import Path
 from types import ModuleType
 from typing import Any, Literal, TypeVar, cast, overload
@@ -2668,6 +2668,15 @@ def _project_result_view(result: ProjectResult) -> hooks_impl.ProjectResultView:
         summary=_summary_view(result.summary),
         queue_size=result.queue_size,
     )
+
+
+def _env_path(env: Mapping[str, str]) -> list[str]:
+    value = env.get("PATH", "")
+    return value.split(os.pathsep) if value else []
+
+
+def _apply_env_path(env: MutableMapping[str, str], path: Sequence[str | os.PathLike[str]]) -> None:
+    env["PATH"] = os.pathsep.join(os.fspath(entry) for entry in path)
 
 
 def _fixture_views(
@@ -5733,13 +5742,20 @@ def run_fixture_mode_cli(
             except RuntimeError as exc:
                 raise HarnessError(f"error: {exc}") from exc
             env = os.environ.copy()
+            path = _env_path(env)
             _invoke_hooks(
                 (root_hooks,),
                 "startup",
-                hooks_impl.StartupContext(root=root_path, env=env, debug=debug_enabled),
+                hooks_impl.StartupContext(
+                    root=root_path,
+                    env=hooks_impl.HookEnvironment(env, path),
+                    path=path,
+                    debug=debug_enabled,
+                ),
                 project_root=root_path,
                 debug=debug_enabled,
             )
+            _apply_env_path(env, path)
             os.environ.clear()
             os.environ.update(env)
             startup_succeeded = True
@@ -5928,13 +5944,20 @@ def run_cli(
             raise HarnessError(f"error: {exc}") from exc
         if not _HOOKS_DISABLED:
             env = os.environ.copy()
+            path = _env_path(env)
             _invoke_hooks(
                 (root_hooks,),
                 "startup",
-                hooks_impl.StartupContext(root=root_path, env=env, debug=debug_enabled),
+                hooks_impl.StartupContext(
+                    root=root_path,
+                    env=hooks_impl.HookEnvironment(env, path),
+                    path=path,
+                    debug=debug_enabled,
+                ),
                 project_root=root_path,
                 debug=debug_enabled,
             )
+            _apply_env_path(env, path)
             os.environ.clear()
             os.environ.update(env)
             startup_succeeded = True
@@ -6049,6 +6072,7 @@ def run_cli(
                 project_view = _project_view(selection)
                 project_env = os.environ.copy()
                 project_env["TENZIR_EXEC__DUMP_DIAGNOSTICS"] = "true"
+                project_path = _env_path(project_env)
                 next_selection = next(
                     (
                         candidate
@@ -6065,7 +6089,8 @@ def run_cli(
                         project=project_view,
                         previous_project=previous_project_view,
                         kind=selection.kind,
-                        env=project_env,
+                        env=hooks_impl.HookEnvironment(project_env, project_path),
+                        path=project_path,
                         debug=debug_enabled,
                         update=update,
                         coverage=coverage,
@@ -6073,6 +6098,7 @@ def run_cli(
                     project_root=selection.root,
                     debug=debug_enabled,
                 )
+                _apply_env_path(project_env, project_path)
                 global _CURRENT_PROJECT_ENV, _CURRENT_PROJECT_VIEW, _CURRENT_HOOK_CHAIN
                 _CURRENT_PROJECT_ENV = project_env
                 _CURRENT_PROJECT_VIEW = project_view

--- a/src/tenzir_test/run.py
+++ b/src/tenzir_test/run.py
@@ -2843,7 +2843,7 @@ def get_test_env_and_config_args(
     config_file = test.parent / "tenzir.yaml"
     node_config_file = test.parent / "tenzir-node.yaml"
     config_args = [f"--config={config_file}"] if config_file.exists() else []
-    env = (_CURRENT_PROJECT_ENV or os.environ).copy()
+    env = (os.environ if _CURRENT_PROJECT_ENV is None else _CURRENT_PROJECT_ENV).copy()
     if inputs is None:
         # Try nearest inputs/ directory first, fall back to project-level
         nearest = _find_nearest_inputs_dir(test, ROOT)
@@ -5839,13 +5839,15 @@ def run_fixture_mode_cli(
             _apply_fixture_env(env, fixture_specs)
             _print_fixture_env_lines(fixture_env)
             _wait_for_fixture_shutdown()
-    except fixtures_impl.FixtureUnavailable as exc:
+    except BaseException as exc:
         if startup_succeeded and not shutdown_invoked:
             try:
                 _invoke_fixture_shutdown(1)
             except hooks_impl.HookInvocationError as shutdown_exc:
                 raise HarnessError(f"error: {shutdown_exc}") from exc
-        _raise_fixture_unavailable_harness_error(exc)
+        if isinstance(exc, fixtures_impl.FixtureUnavailable):
+            _raise_fixture_unavailable_harness_error(exc)
+        raise
     finally:
         fixtures_impl.pop_context(context_token)
         cleanup_test_tmp_dir(env.get(TEST_TMP_ENV_VAR))

--- a/src/tenzir_test/run.py
+++ b/src/tenzir_test/run.py
@@ -4611,6 +4611,12 @@ class Worker:
         return self._result
 
     @property
+    def partial_summary(self) -> Summary:
+        """Return the summary accumulated before worker termination."""
+
+        return self._result or Summary()
+
+    @property
     def run_skipped_match_count(self) -> int:
         return self._run_skipped_match_count
 
@@ -5670,6 +5676,16 @@ class Worker:
         return final_interrupted or interrupt_requested()
 
 
+def _worker_partial_summary(worker: object) -> Summary:
+    summary = getattr(worker, "partial_summary", None)
+    if isinstance(summary, Summary):
+        return summary
+    result = getattr(worker, "_result", None)
+    if isinstance(result, Summary):
+        return result
+    return Summary()
+
+
 def get_runner_for_test(test_path: Path) -> Runner:
     """Determine the appropriate runner for a test based on its configuration."""
     return runners_get_runner(test_path)
@@ -6233,6 +6249,24 @@ def run_cli(
                 )
                 project_finish_once = _HookInvocationOnce()
                 project_summary = Summary()
+                project_queue_size = 0
+                project_result_recorded = False
+
+                def _record_project_result_once() -> None:
+                    nonlocal overall_queue_count, project_result_recorded
+                    if project_result_recorded:
+                        return
+                    _merge_summary_inplace(overall_summary, project_summary)
+                    overall_queue_count += project_queue_size
+                    executed_projects.append(selection)
+                    project_results.append(
+                        ProjectResult(
+                            selection=selection,
+                            summary=project_summary,
+                            queue_size=project_queue_size,
+                        )
+                    )
+                    project_result_recorded = True
 
                 def _invoke_project_finish() -> None:
                     project_finish_once.invoke(
@@ -6412,15 +6446,7 @@ def run_cli(
                     )
 
                     if not project_queue_size:
-                        overall_queue_count += project_queue_size
-                        executed_projects.append(selection)
-                        project_results.append(
-                            ProjectResult(
-                                selection=selection,
-                                summary=project_summary,
-                                queue_size=project_queue_size,
-                            )
-                        )
+                        _record_project_result_once()
                         _invoke_project_finish()
                         continue
 
@@ -6493,28 +6519,61 @@ def run_cli(
                     for worker in workers:
                         worker.start()
                     skip_filter_matches = 0
+                    joined_workers: set[Worker] = set()
                     try:
+                        worker_exception: Exception | None = None
                         for worker in workers:
-                            project_summary += worker.join()
+                            try:
+                                worker_summary = worker.join()
+                            except Exception as exc:
+                                _merge_summary_inplace(
+                                    project_summary, _worker_partial_summary(worker)
+                                )
+                                if worker_exception is None:
+                                    worker_exception = exc
+                            else:
+                                _merge_summary_inplace(project_summary, worker_summary)
+                            joined_workers.add(worker)
                             skip_filter_matches += worker.run_skipped_match_count
+                        if worker_exception is not None:
+                            raise worker_exception
                     except KeyboardInterrupt:  # pragma: no cover - defensive guard
                         _request_interrupt()
                         for worker in workers:
-                            worker.join()
+                            if worker in joined_workers:
+                                continue
+                            try:
+                                worker_summary = worker.join()
+                            except Exception:
+                                worker_summary = _worker_partial_summary(worker)
+                            _merge_summary_inplace(project_summary, worker_summary)
+                            skip_filter_matches += worker.run_skipped_match_count
+                        _record_project_result_once()
                         interrupted = True
                         break
                     except fixtures_impl.FixtureUnavailable as exc:
+                        _record_project_result_once()
                         _raise_fixture_unavailable_harness_error(exc)
                     except Exception as exc:
                         if not (_exception_is_interrupt(exc) or interrupt_requested()):
+                            _record_project_result_once()
                             raise
                         _request_interrupt()
                         for remaining_worker in workers:
+                            if remaining_worker in joined_workers:
+                                continue
                             try:
-                                remaining_worker.join()
+                                worker_summary = remaining_worker.join()
                             except Exception as join_exc:
+                                worker_summary = _worker_partial_summary(remaining_worker)
                                 if not (_exception_is_interrupt(join_exc) or interrupt_requested()):
+                                    _merge_summary_inplace(project_summary, worker_summary)
+                                    skip_filter_matches += remaining_worker.run_skipped_match_count
+                                    _record_project_result_once()
                                     raise
+                            _merge_summary_inplace(project_summary, worker_summary)
+                            skip_filter_matches += remaining_worker.run_skipped_match_count
+                        _record_project_result_once()
                         interrupted = True
                         break
                     if run_skipped_selector.has_reason_filters and skip_filter_matches == 0:
@@ -6541,16 +6600,7 @@ def run_cli(
                         print(f"{INFO} Code coverage data collected in {coverage_dir}")
                         print(f"{INFO} Source directory for coverage mapping: {source_dir}")
 
-                    overall_summary += project_summary
-                    overall_queue_count += project_queue_size
-                    executed_projects.append(selection)
-                    project_results.append(
-                        ProjectResult(
-                            selection=selection,
-                            summary=project_summary,
-                            queue_size=project_queue_size,
-                        )
-                    )
+                    _record_project_result_once()
                     _invoke_project_finish()
 
                     if interrupt_requested():

--- a/src/tenzir_test/run.py
+++ b/src/tenzir_test/run.py
@@ -33,6 +33,7 @@ from typing import Any, Literal, TypeVar, cast, overload
 import yaml
 
 import tenzir_test.fixtures as fixtures_impl
+from . import hooks as hooks_impl
 from . import packages
 from .config import Settings, discover_settings
 from .runners import (
@@ -1105,6 +1106,17 @@ def set_keep_tmp_dirs(enabled: bool) -> None:
 
 
 def cleanup_test_tmp_dir(path: str | os.PathLike[str] | None) -> None:
+    if not path:
+        return
+    tmp_path = Path(path)
+    deferred = _DEFER_TMP_CLEANUP.get()
+    if deferred is not None:
+        deferred.append(tmp_path)
+        return
+    _cleanup_test_tmp_dir_now(tmp_path)
+
+
+def _cleanup_test_tmp_dir_now(path: str | os.PathLike[str] | None) -> None:
     if not path:
         return
     tmp_path = Path(path)
@@ -2491,7 +2503,7 @@ def _iter_project_test_directories(root: Path) -> Iterator[Path]:
     for dir_path in root.iterdir():
         if not dir_path.is_dir() or dir_path.name.startswith("."):
             continue
-        if dir_path.name in {"fixtures", "runners"}:
+        if dir_path.name in {"fixtures", "runners", "hooks"}:
             continue
         if _is_inputs_path(dir_path):
             continue
@@ -2606,8 +2618,112 @@ def _import_module_from_path(module_name: str, path: Path, *, package: bool = Fa
     return module
 
 
+def _hooks_disabled(no_hooks: bool = False) -> bool:
+    return no_hooks or bool(os.environ.get("TENZIR_TEST_DISABLE_HOOKS"))
+
+
+def _load_project_hooks(root: Path) -> hooks_impl.HookSet:
+    if _HOOKS_DISABLED:
+        return hooks_impl.HookSet()
+    resolved_root = root.resolve()
+    cached = _HOOK_LOAD_CACHE.get(resolved_root)
+    if cached is not None:
+        return cached
+
+    hook_set = hooks_impl.HookSet()
+    hooks_package = resolved_root / "hooks"
+    hooks_file = resolved_root / "hooks.py"
+    module_base = f"_tenzir_project_hooks_{abs(hash(str(resolved_root)))}"
+    try:
+        with hooks_impl.loading() as loading_set:
+            if hooks_package.is_dir() and (hooks_package / "__init__.py").exists():
+                path = hooks_package / "__init__.py"
+                _CLI_LOGGER.debug("loading hooks from %s", path)
+                _import_module_from_path(module_base, path, package=True)
+            elif hooks_file.exists():
+                _CLI_LOGGER.debug("loading hooks from %s", hooks_file)
+                _import_module_from_path(module_base, hooks_file)
+            hook_set = loading_set
+    except Exception as exc:
+        raise RuntimeError(f"failed to load hooks from {resolved_root}: {exc}") from exc
+    _HOOK_LOAD_CACHE[resolved_root] = hook_set
+    return hook_set
+
+
+def _summary_view(summary: Summary) -> hooks_impl.SummaryView:
+    return hooks_impl.SummaryView(
+        failed=summary.failed,
+        total=summary.total,
+        skipped=summary.skipped,
+    )
+
+
+def _project_view(selection: ProjectSelection) -> hooks_impl.ProjectView:
+    return hooks_impl.ProjectView(root=selection.root, kind=selection.kind)
+
+
+def _project_result_view(result: ProjectResult) -> hooks_impl.ProjectResultView:
+    return hooks_impl.ProjectResultView(
+        project=_project_view(result.selection),
+        summary=_summary_view(result.summary),
+        queue_size=result.queue_size,
+    )
+
+
+def _fixture_views(
+    specs: tuple[fixtures_impl.FixtureSpec, ...],
+) -> tuple[hooks_impl.FixtureSpecView, ...]:
+    return tuple(
+        hooks_impl.FixtureSpecView(name=spec.name, options=getattr(spec, "options", None))
+        for spec in specs
+    )
+
+
+def _suite_view(
+    suite_progress: tuple[str, int, int] | None,
+    test_path: Path,
+) -> hooks_impl.SuiteView | None:
+    if suite_progress is None:
+        return None
+    info = _resolve_suite_for_test(test_path)
+    if info is None:
+        return None
+    return hooks_impl.SuiteView(name=info.name, directory=info.directory)
+
+
+def _invoke_hooks(
+    hook_chain: Sequence[hooks_impl.HookSet],
+    event: hooks_impl.HookEvent,
+    context: object,
+    *,
+    reverse: bool = False,
+    project_root: Path | None = None,
+    test_path: Path | None = None,
+    debug: bool = False,
+) -> None:
+    if _HOOKS_DISABLED:
+        return
+    hooks_impl.invoke(
+        hook_chain,
+        event,
+        context,
+        reverse=reverse,
+        project_root=project_root,
+        test_path=test_path,
+        debug=debug,
+    )
+
+
 _FIXTURE_LOAD_ROOTS: set[Path] = set()
 _RUNNER_LOAD_ROOTS: set[Path] = set()
+_HOOK_LOAD_CACHE: dict[Path, hooks_impl.HookSet] = {}
+_CURRENT_PROJECT_ENV: dict[str, str] | None = None
+_CURRENT_PROJECT_VIEW: hooks_impl.ProjectView | None = None
+_CURRENT_HOOK_CHAIN: tuple[hooks_impl.HookSet, ...] = tuple()
+_HOOKS_DISABLED = False
+_DEFER_TMP_CLEANUP: contextvars.ContextVar[list[Path] | None] = contextvars.ContextVar(
+    "tenzir_test_defer_tmp_cleanup", default=None
+)
 
 
 def _format_missing_fixture_dependency_error(
@@ -2718,7 +2834,7 @@ def get_test_env_and_config_args(
     config_file = test.parent / "tenzir.yaml"
     node_config_file = test.parent / "tenzir-node.yaml"
     config_args = [f"--config={config_file}"] if config_file.exists() else []
-    env = os.environ.copy()
+    env = (_CURRENT_PROJECT_ENV or os.environ).copy()
     if inputs is None:
         # Try nearest inputs/ directory first, fall back to project-level
         nearest = _find_nearest_inputs_dir(test, ROOT)
@@ -4400,6 +4516,8 @@ class Worker:
         slot_lock: threading.Lock | None = None,
         queue_lock: threading.Lock | None = None,
         suite_queue_state: SuiteQueueState | None = None,
+        hook_chain: Sequence[hooks_impl.HookSet] = (),
+        project_view: hooks_impl.ProjectView | None = None,
     ) -> None:
         self._queue = queue
         self._result: Summary | None = None
@@ -4420,6 +4538,8 @@ class Worker:
             self._suite_queue_state = suite_queue_state
         self._run_skipped_match_count = 0
         self._run_skipped_match_count_lock = threading.Lock()
+        self._hook_chain = tuple(hook_chain)
+        self._project_view = project_view or hooks_impl.ProjectView(root=ROOT, kind="root")
         self._thread = threading.Thread(target=self._work)
 
     def __del__(self) -> None:
@@ -4543,6 +4663,29 @@ class Worker:
             summary.record_fixture_outcome(_fixture_names(fixtures), "skipped")
         summary.skipped += 1
         summary.skipped_paths.append(rel_path)
+        _invoke_hooks(
+            self._hook_chain,
+            "test_finish",
+            hooks_impl.TestFinishContext(
+                root=ROOT,
+                project=self._project_view,
+                test=test_item.path,
+                runner=test_item.runner.name,
+                outcome="skipped",
+                reason=reason,
+                attempts=0,
+                duration=0.0,
+                fixtures=_fixture_views(fixtures),
+                suite=None,
+                tmp_dir=None,
+                update=self._update,
+                coverage=self._coverage,
+            ),
+            reverse=True,
+            project_root=ROOT,
+            test_path=test_item.path,
+            debug=self._debug,
+        )
 
     def _record_static_skip(
         self,
@@ -4606,6 +4749,32 @@ class Worker:
             summary.skipped_paths.append(rel_path)
             summary.record_runner_outcome(test_item.runner.name, "skipped")
             summary.record_fixture_outcome(_fixture_names(suite_item.fixtures), "skipped")
+            _invoke_hooks(
+                self._hook_chain,
+                "test_finish",
+                hooks_impl.TestFinishContext(
+                    root=ROOT,
+                    project=self._project_view,
+                    test=test_item.path,
+                    runner=test_item.runner.name,
+                    outcome="skipped",
+                    reason=displayed_reason,
+                    attempts=0,
+                    duration=0.0,
+                    fixtures=_fixture_views(suite_item.fixtures),
+                    suite=hooks_impl.SuiteView(
+                        name=suite_item.suite.name,
+                        directory=suite_item.suite.directory,
+                    ),
+                    tmp_dir=None,
+                    update=self._update,
+                    coverage=self._coverage,
+                ),
+                reverse=True,
+                project_root=ROOT,
+                test_path=test_item.path,
+                debug=self._debug,
+            )
         return True
 
     def _evaluate_suite_requirements(
@@ -5084,6 +5253,7 @@ class Worker:
                     return False
             # Capability skips are suite-level. Fixture-unavailable skips can
             # also apply to per-test fixture activation below.
+        suite_view = _suite_view(suite_progress, test_path)
         if parse_error is not None:
             message = format_failure_message(parse_error)
             report_failure(test_path, message)
@@ -5093,6 +5263,52 @@ class Worker:
                 summary.record_fixture_outcome(_fixture_names(fixtures), False)
             summary.failed += 1
             summary.failed_paths.append(rel_path)
+            finish_ctx = hooks_impl.TestFinishContext(
+                root=ROOT,
+                project=self._project_view,
+                test=test_path,
+                runner=runner.name,
+                outcome="failed",
+                reason=parse_error,
+                attempts=0,
+                duration=0.0,
+                fixtures=_fixture_views(fixtures),
+                suite=suite_view,
+                tmp_dir=None,
+                update=self._update,
+                coverage=self._coverage,
+            )
+            _invoke_hooks(
+                self._hook_chain,
+                "test_finish",
+                finish_ctx,
+                reverse=True,
+                project_root=ROOT,
+                test_path=test_path,
+                debug=self._debug,
+            )
+            _invoke_hooks(
+                self._hook_chain,
+                "test_failure",
+                hooks_impl.TestFailureContext(
+                    root=finish_ctx.root,
+                    project=finish_ctx.project,
+                    test=finish_ctx.test,
+                    runner=finish_ctx.runner,
+                    reason=finish_ctx.reason,
+                    attempts=finish_ctx.attempts,
+                    duration=finish_ctx.duration,
+                    fixtures=finish_ctx.fixtures,
+                    suite=finish_ctx.suite,
+                    tmp_dir=finish_ctx.tmp_dir,
+                    update=finish_ctx.update,
+                    coverage=finish_ctx.coverage,
+                ),
+                reverse=True,
+                project_root=ROOT,
+                test_path=test_path,
+                debug=self._debug,
+            )
             return False
         detail_bits = [f"runner={runner.name}"]
         if fixtures:
@@ -5110,6 +5326,27 @@ class Worker:
         attempts = 0
         final_outcome: bool | str = False
         final_interrupted = False
+        started_at = time.monotonic()
+        deferred_tmp_dirs: list[Path] = []
+        _invoke_hooks(
+            self._hook_chain,
+            "test_start",
+            hooks_impl.TestStartContext(
+                root=ROOT,
+                project=self._project_view,
+                test=test_path,
+                runner=runner.name,
+                fixtures=_fixture_views(fixtures),
+                suite=suite_view,
+                update=self._update,
+                coverage=self._coverage,
+                attempt_limit=max_attempts,
+            ),
+            project_root=ROOT,
+            test_path=test_path,
+            debug=self._debug,
+        )
+        cleanup_token = _DEFER_TMP_CLEANUP.set(deferred_tmp_dirs)
         while attempts < max_attempts:
             if interrupt_requested():
                 final_interrupted = True
@@ -5165,6 +5402,9 @@ class Worker:
                                 displayed_reason=displayed_reason,
                                 summary=summary,
                             ):
+                                _DEFER_TMP_CLEANUP.reset(cleanup_token)
+                                for path in deferred_tmp_dirs:
+                                    _cleanup_test_tmp_dir_now(path)
                                 return False
                             raise
                         report_failure(
@@ -5218,6 +5458,9 @@ class Worker:
                     break
                 if attempts < max_attempts:
                     continue
+        _DEFER_TMP_CLEANUP.reset(cleanup_token)
+        tmp_dir = deferred_tmp_dirs[-1] if deferred_tmp_dirs else None
+        duration = time.monotonic() - started_at
         if attempts == 0 and final_interrupted:
             # The test never started an execution attempt (for example, work
             # was cancelled after an interrupt), so do not count it as failed.
@@ -5233,6 +5476,62 @@ class Worker:
         elif not final_outcome:
             summary.failed += 1
             summary.failed_paths.append(rel_path)
+        if final_outcome == "skipped":
+            outcome_name: Literal["passed", "failed", "skipped"] = "skipped"
+        elif final_outcome:
+            outcome_name = "passed"
+        else:
+            outcome_name = "failed"
+        finish_reason: str | None = _INTERRUPTED_NOTICE if final_interrupted else None
+        finish_ctx = hooks_impl.TestFinishContext(
+            root=ROOT,
+            project=self._project_view,
+            test=test_path,
+            runner=runner.name,
+            outcome=outcome_name,
+            reason=finish_reason,
+            attempts=attempts,
+            duration=duration,
+            fixtures=_fixture_views(fixtures),
+            suite=suite_view,
+            tmp_dir=tmp_dir,
+            update=self._update,
+            coverage=self._coverage,
+        )
+        _invoke_hooks(
+            self._hook_chain,
+            "test_finish",
+            finish_ctx,
+            reverse=True,
+            project_root=ROOT,
+            test_path=test_path,
+            debug=self._debug,
+        )
+        if outcome_name == "failed":
+            _invoke_hooks(
+                self._hook_chain,
+                "test_failure",
+                hooks_impl.TestFailureContext(
+                    root=finish_ctx.root,
+                    project=finish_ctx.project,
+                    test=finish_ctx.test,
+                    runner=finish_ctx.runner,
+                    reason=finish_ctx.reason,
+                    attempts=finish_ctx.attempts,
+                    duration=finish_ctx.duration,
+                    fixtures=finish_ctx.fixtures,
+                    suite=finish_ctx.suite,
+                    tmp_dir=finish_ctx.tmp_dir,
+                    update=finish_ctx.update,
+                    coverage=finish_ctx.coverage,
+                ),
+                reverse=True,
+                project_root=ROOT,
+                test_path=test_path,
+                debug=self._debug,
+            )
+        for path in deferred_tmp_dirs:
+            _cleanup_test_tmp_dir_now(path)
         return final_interrupted or interrupt_requested()
 
 
@@ -5242,7 +5541,7 @@ def get_runner_for_test(test_path: Path) -> Runner:
 
 
 def collect_all_tests(directory: Path) -> Iterator[Path]:
-    if directory.name in {"fixtures", "runners"}:
+    if directory.name in {"fixtures", "runners", "hooks"}:
         return
     extensions = _allowed_extensions or {
         ext
@@ -5411,6 +5710,7 @@ def run_fixture_mode_cli(
     fixtures: Sequence[str],
     debug: bool,
     keep_tmp_dirs: bool,
+    no_hooks: bool = False,
 ) -> int:
     """Activate requested fixtures in foreground mode until interrupted."""
 
@@ -5420,8 +5720,26 @@ def run_fixture_mode_cli(
     debug_enabled = bool(debug or _default_debug_logging)
     _configure_runtime_logging(debug_enabled=debug_enabled)
     set_keep_tmp_dirs(bool(os.environ.get(_TMP_KEEP_ENV_VAR)) or keep_tmp_dirs)
+    global _HOOKS_DISABLED
+    _HOOKS_DISABLED = _hooks_disabled(no_hooks)
+    root_path = Path(root or os.environ.get("TENZIR_TEST_ROOT") or Path.cwd()).resolve()
+    if not _HOOKS_DISABLED:
+        try:
+            root_hooks = _load_project_hooks(root_path)
+        except RuntimeError as exc:
+            raise HarnessError(f"error: {exc}") from exc
+        env = os.environ.copy()
+        _invoke_hooks(
+            (root_hooks,),
+            "startup",
+            hooks_impl.StartupContext(root=root_path, env=env, debug=debug_enabled),
+            project_root=root_path,
+            debug=debug_enabled,
+        )
+        os.environ.clear()
+        os.environ.update(env)
 
-    settings = discover_settings(root=root)
+    settings = discover_settings(root=root_path)
     apply_settings(settings)
     _set_cli_packages(list(package_dirs or []))
 
@@ -5511,6 +5829,7 @@ def run_cli(
     jobs_overridden: bool = False,
     all_projects: bool = False,
     match_patterns: Sequence[str] = (),
+    no_hooks: bool = False,
 ) -> ExecutionResult:
     """Execute the harness and return a structured result for library consumers.
 
@@ -5557,7 +5876,26 @@ def run_cli(
             print(f"{INFO} ignoring --update in passthrough mode")
             update = False
 
-        settings = discover_settings(root=root)
+        global _HOOKS_DISABLED
+        _HOOKS_DISABLED = _hooks_disabled(no_hooks)
+        root_path = Path(root or os.environ.get("TENZIR_TEST_ROOT") or Path.cwd()).resolve()
+        try:
+            root_hooks = hooks_impl.HookSet() if _HOOKS_DISABLED else _load_project_hooks(root_path)
+        except RuntimeError as exc:
+            raise HarnessError(f"error: {exc}") from exc
+        if not _HOOKS_DISABLED:
+            env = os.environ.copy()
+            _invoke_hooks(
+                (root_hooks,),
+                "startup",
+                hooks_impl.StartupContext(root=root_path, env=env, debug=debug_enabled),
+                project_root=root_path,
+                debug=debug_enabled,
+            )
+            os.environ.clear()
+            os.environ.update(env)
+
+        settings = discover_settings(root=root_path)
         apply_settings(settings)
         _set_cli_packages(list(package_dirs or []))
         selected_tests = list(tests)
@@ -5623,8 +5961,10 @@ def run_cli(
             project_results: list[ProjectResult] = []
             printed_projects = 0
             interrupted = False
+            plan_projects = list(plan.projects())
+            previous_project_view: hooks_impl.ProjectView | None = None
 
-            for selection in plan.projects():
+            for project_index, selection in enumerate(plan_projects):
                 if interrupt_requested():
                     break
                 if not selection.should_run():
@@ -5653,10 +5993,50 @@ def run_cli(
                 except RuntimeError as exc:
                     raise HarnessError(f"error: {exc}") from exc
                 refresh_runner_metadata()
+                project_hooks = root_hooks
+                if selection.root.resolve() != settings.root.resolve() and not _HOOKS_DISABLED:
+                    try:
+                        project_hooks = _load_project_hooks(selection.root)
+                    except RuntimeError as exc:
+                        raise HarnessError(f"error: {exc}") from exc
+                hook_chain = (
+                    (root_hooks,) if selection.kind == "root" else (root_hooks, project_hooks)
+                )
+                project_view = _project_view(selection)
+                project_env = os.environ.copy()
+                next_selection = next(
+                    (
+                        candidate
+                        for candidate in plan_projects[project_index + 1 :]
+                        if candidate.should_run()
+                    ),
+                    None,
+                )
+                _invoke_hooks(
+                    hook_chain,
+                    "project_start",
+                    hooks_impl.ProjectStartContext(
+                        root=settings.root,
+                        project=project_view,
+                        previous_project=previous_project_view,
+                        kind=selection.kind,
+                        env=project_env,
+                        debug=debug_enabled,
+                        update=update,
+                        coverage=coverage,
+                    ),
+                    project_root=selection.root,
+                    debug=debug_enabled,
+                )
+                global _CURRENT_PROJECT_ENV, _CURRENT_PROJECT_VIEW, _CURRENT_HOOK_CHAIN
+                _CURRENT_PROJECT_ENV = project_env
+                _CURRENT_PROJECT_VIEW = project_view
+                _CURRENT_HOOK_CHAIN = hook_chain
 
                 tests_to_run = selection.selectors if not selection.run_all else [selection.root]
 
                 if purge:
+                    previous_project_view = project_view
                     continue
 
                 collected_paths: set[Path] = set()
@@ -5788,6 +6168,26 @@ def run_cli(
                             queue_size=project_queue_size,
                         )
                     )
+                    _invoke_hooks(
+                        hook_chain,
+                        "project_finish",
+                        hooks_impl.ProjectFinishContext(
+                            root=settings.root,
+                            project=project_view,
+                            next_project=_project_view(next_selection) if next_selection else None,
+                            kind=selection.kind,
+                            summary=_summary_view(project_summary),
+                            interrupted=interrupted or interrupt_requested(),
+                            debug=debug_enabled,
+                        ),
+                        reverse=True,
+                        project_root=selection.root,
+                        debug=debug_enabled,
+                    )
+                    previous_project_view = project_view
+                    _CURRENT_PROJECT_ENV = None
+                    _CURRENT_PROJECT_VIEW = None
+                    _CURRENT_HOOK_CHAIN = tuple()
                     continue
 
                 os.environ["TENZIR_EXEC__DUMP_DIAGNOSTICS"] = "true"
@@ -5846,6 +6246,8 @@ def run_cli(
                         slot_lock=slot_lock,
                         queue_lock=queue_lock,
                         suite_queue_state=suite_queue_state,
+                        hook_chain=hook_chain,
+                        project_view=project_view,
                     )
                     for _ in range(jobs)
                 ]
@@ -5908,6 +6310,26 @@ def run_cli(
                         queue_size=project_queue_size,
                     )
                 )
+                _invoke_hooks(
+                    hook_chain,
+                    "project_finish",
+                    hooks_impl.ProjectFinishContext(
+                        root=settings.root,
+                        project=project_view,
+                        next_project=_project_view(next_selection) if next_selection else None,
+                        kind=selection.kind,
+                        summary=_summary_view(project_summary),
+                        interrupted=interrupted or interrupt_requested(),
+                        debug=debug_enabled,
+                    ),
+                    reverse=True,
+                    project_root=selection.root,
+                    debug=debug_enabled,
+                )
+                previous_project_view = project_view
+                _CURRENT_PROJECT_ENV = None
+                _CURRENT_PROJECT_VIEW = None
+                _CURRENT_HOOK_CHAIN = tuple()
 
                 if interrupt_requested():
                     break
@@ -5916,51 +6338,85 @@ def run_cli(
             _set_project_root(settings.root)
             engine_state.refresh()
 
+            def _finish_result(result: ExecutionResult) -> ExecutionResult:
+                _invoke_hooks(
+                    (root_hooks,),
+                    "shutdown",
+                    hooks_impl.ShutdownContext(
+                        root=settings.root,
+                        exit_code=result.exit_code,
+                        interrupted=result.interrupted,
+                        summary=_summary_view(result.summary),
+                        project_results=tuple(
+                            _project_result_view(item) for item in result.project_results
+                        ),
+                        debug=debug_enabled,
+                    ),
+                    reverse=True,
+                    project_root=settings.root,
+                    debug=debug_enabled,
+                )
+                return result
+
             interrupted = interrupted or interrupt_requested()
             if interrupted:
-                return ExecutionResult(
-                    summary=overall_summary,
-                    project_results=tuple(project_results),
-                    queue_size=overall_queue_count,
-                    exit_code=130,
-                    interrupted=True,
+                return _finish_result(
+                    ExecutionResult(
+                        summary=overall_summary,
+                        project_results=tuple(project_results),
+                        queue_size=overall_queue_count,
+                        exit_code=130,
+                        interrupted=True,
+                    )
                 )
 
             if purge:
                 for runner in runners_iter_runners():
                     runner.purge()
-                return ExecutionResult(
-                    summary=overall_summary,
-                    project_results=tuple(project_results),
-                    queue_size=overall_queue_count,
-                    exit_code=0,
-                    interrupted=interrupted,
+                return _finish_result(
+                    ExecutionResult(
+                        summary=overall_summary,
+                        project_results=tuple(project_results),
+                        queue_size=overall_queue_count,
+                        exit_code=0,
+                        interrupted=interrupted,
+                    )
                 )
 
             if overall_queue_count == 0:
                 print(f"{INFO} no tests selected")
-                return ExecutionResult(
-                    summary=overall_summary,
-                    project_results=tuple(project_results),
-                    queue_size=overall_queue_count,
-                    exit_code=0,
-                    interrupted=interrupted,
+                return _finish_result(
+                    ExecutionResult(
+                        summary=overall_summary,
+                        project_results=tuple(project_results),
+                        queue_size=overall_queue_count,
+                        exit_code=0,
+                        interrupted=interrupted,
+                    )
                 )
 
             if len(executed_projects) > 1:
                 _print_aggregate_totals(len(executed_projects), overall_summary)
 
             exit_code = 1 if overall_summary.failed > 0 else 0
-            return ExecutionResult(
-                summary=overall_summary,
-                project_results=tuple(project_results),
-                queue_size=overall_queue_count,
-                exit_code=exit_code,
-                interrupted=False,
+            return _finish_result(
+                ExecutionResult(
+                    summary=overall_summary,
+                    project_results=tuple(project_results),
+                    queue_size=overall_queue_count,
+                    exit_code=exit_code,
+                    interrupted=False,
+                )
             )
 
+    except hooks_impl.HookInvocationError as exc:
+        raise HarnessError(f"error: {exc}") from exc
     finally:
         _cleanup_all_tmp_dirs()
+        _CURRENT_PROJECT_ENV = None
+        _CURRENT_PROJECT_VIEW = None
+        _CURRENT_HOOK_CHAIN = tuple()
+        _HOOKS_DISABLED = _hooks_disabled(False)
 
 
 def execute(
@@ -5986,6 +6442,7 @@ def execute(
     jobs_overridden: bool = False,
     all_projects: bool = False,
     match_patterns: Sequence[str] = (),
+    no_hooks: bool = False,
 ) -> ExecutionResult:
     """Library-oriented wrapper around `run_cli` with defaulted parameters.
 
@@ -6027,6 +6484,7 @@ def execute(
         jobs_overridden=jobs_overridden,
         all_projects=all_projects,
         match_patterns=match_patterns,
+        no_hooks=no_hooks,
     )
 
 

--- a/src/tenzir_test/run.py
+++ b/src/tenzir_test/run.py
@@ -2676,7 +2676,10 @@ def _env_path(env: Mapping[str, str]) -> list[str]:
 
 
 def _apply_env_path(env: MutableMapping[str, str], path: Sequence[str | os.PathLike[str]]) -> None:
-    env["PATH"] = os.pathsep.join(os.fspath(entry) for entry in path)
+    if path:
+        env["PATH"] = os.pathsep.join(os.fspath(entry) for entry in path)
+    else:
+        env.pop("PATH", None)
 
 
 def _fixture_views(
@@ -4698,6 +4701,7 @@ class Worker:
         fixtures: tuple[fixtures_impl.FixtureSpec, ...],
         reason: str,
         summary: Summary,
+        suite: hooks_impl.SuiteView | None = None,
     ) -> None:
         handle_skip(
             reason,
@@ -4725,7 +4729,7 @@ class Worker:
                 attempts=0,
                 duration=0.0,
                 fixtures=_fixture_views(fixtures),
-                suite=None,
+                suite=suite,
                 tmp_dir=None,
                 update=self._update,
                 coverage=self._coverage,
@@ -4743,12 +4747,14 @@ class Worker:
         fixtures: tuple[fixtures_impl.FixtureSpec, ...],
         reason: str,
         summary: Summary,
+        suite: hooks_impl.SuiteView | None = None,
     ) -> None:
         self._record_test_skip(
             test_item=test_item,
             fixtures=fixtures,
             reason=reason,
             summary=summary,
+            suite=suite,
         )
 
     def _skip_test_with_reason(
@@ -5110,12 +5116,17 @@ class Worker:
             # Avoid activating suite fixtures when every suite member is statically skipped.
             static_skip_plan = self._suite_static_skip_plan(suite_item)
             if static_skip_plan is not None:
+                suite_view = hooks_impl.SuiteView(
+                    name=suite_item.suite.name,
+                    directory=suite_item.suite.directory,
+                )
                 for test_item, reason in static_skip_plan:
                     self._record_static_skip(
                         test_item=test_item,
                         fixtures=suite_item.fixtures,
                         reason=reason,
                         summary=summary,
+                        suite=suite_view,
                     )
                 return
             inputs_override = typing.cast(str | None, suite_config.get("inputs"))
@@ -5377,24 +5388,50 @@ class Worker:
         final_interrupted = False
         started_at = time.monotonic()
         deferred_tmp_dirs: list[Path] = []
-        _invoke_hooks(
-            self._hook_chain,
-            "test_start",
-            hooks_impl.TestStartContext(
-                root=self._hook_root,
-                project=self._project_view,
-                test=test_path,
-                runner=runner.name,
-                fixtures=_fixture_views(fixtures),
-                suite=suite_view,
-                update=self._update,
-                coverage=self._coverage,
-                attempt_limit=max_attempts,
-            ),
-            project_root=self._hook_root,
-            test_path=test_path,
-            debug=self._debug,
-        )
+        try:
+            _invoke_hooks(
+                self._hook_chain,
+                "test_start",
+                hooks_impl.TestStartContext(
+                    root=self._hook_root,
+                    project=self._project_view,
+                    test=test_path,
+                    runner=runner.name,
+                    fixtures=_fixture_views(fixtures),
+                    suite=suite_view,
+                    update=self._update,
+                    coverage=self._coverage,
+                    attempt_limit=max_attempts,
+                ),
+                project_root=self._hook_root,
+                test_path=test_path,
+                debug=self._debug,
+            )
+        except hooks_impl.HookInvocationError:
+            _invoke_hooks(
+                self._hook_chain,
+                "test_finish",
+                hooks_impl.TestFinishContext(
+                    root=self._hook_root,
+                    project=self._project_view,
+                    test=test_path,
+                    runner=runner.name,
+                    outcome="failed",
+                    reason="test_start hook failed",
+                    attempts=0,
+                    duration=time.monotonic() - started_at,
+                    fixtures=_fixture_views(fixtures),
+                    suite=suite_view,
+                    tmp_dir=None,
+                    update=self._update,
+                    coverage=self._coverage,
+                ),
+                reverse=True,
+                project_root=self._hook_root,
+                test_path=test_path,
+                debug=self._debug,
+            )
+            raise
         cleanup_token = _DEFER_TMP_CLEANUP.set(deferred_tmp_dirs)
         while attempts < max_attempts:
             if interrupt_requested():
@@ -5783,6 +5820,7 @@ def run_fixture_mode_cli(
                 raise HarnessError(f"error: {exc}") from exc
             env = os.environ.copy()
             path = _env_path(env)
+            startup_succeeded = True
             _invoke_hooks(
                 (root_hooks,),
                 "startup",
@@ -5798,19 +5836,36 @@ def run_fixture_mode_cli(
             _apply_env_path(env, path)
             os.environ.clear()
             os.environ.update(env)
-            startup_succeeded = True
     except hooks_impl.HookInvocationError as exc:
+        if startup_succeeded and not shutdown_once.attempted:
+            try:
+                shutdown_once.invoke(
+                    (root_hooks,),
+                    "shutdown",
+                    hooks_impl.ShutdownContext(
+                        root=root_path,
+                        exit_code=1,
+                        interrupted=False,
+                        summary=hooks_impl.SummaryView(failed=0, total=0, skipped=0),
+                        project_results=tuple(),
+                        debug=debug_enabled,
+                    ),
+                    reverse=True,
+                    project_root=root_path,
+                    debug=debug_enabled,
+                )
+            except hooks_impl.HookInvocationError as shutdown_exc:
+                raise HarnessError(f"error: {exc}; additionally, {shutdown_exc}") from exc
         raise HarnessError(f"error: {exc}") from exc
 
-    settings = discover_settings(root=root_path)
-    apply_settings(settings)
+    settings: Settings | None = None
 
-    def _invoke_fixture_shutdown(exit_code: int) -> None:
+    def _invoke_fixture_shutdown(exit_code: int, *, shutdown_root: Path) -> None:
         shutdown_once.invoke(
             (root_hooks,),
             "shutdown",
             hooks_impl.ShutdownContext(
-                root=settings.root,
+                root=shutdown_root,
                 exit_code=exit_code,
                 interrupted=False,
                 summary=hooks_impl.SummaryView(failed=0, total=0, skipped=0),
@@ -5818,11 +5873,13 @@ def run_fixture_mode_cli(
                 debug=debug_enabled,
             ),
             reverse=True,
-            project_root=settings.root,
+            project_root=shutdown_root,
             debug=debug_enabled,
         )
 
     try:
+        settings = discover_settings(root=root_path)
+        apply_settings(settings)
         _set_cli_packages(list(package_dirs or []))
 
         try:
@@ -5882,12 +5939,13 @@ def run_fixture_mode_cli(
             fixtures_impl.pop_context(context_token)
             cleanup_test_tmp_dir(env.get(TEST_TMP_ENV_VAR))
 
-        _invoke_fixture_shutdown(0)
+        _invoke_fixture_shutdown(0, shutdown_root=settings.root)
         return 0
     except BaseException as exc:
         if startup_succeeded and not shutdown_once.attempted:
             try:
-                _invoke_fixture_shutdown(1)
+                shutdown_root = settings.root if settings is not None else root_path
+                _invoke_fixture_shutdown(1, shutdown_root=shutdown_root)
             except hooks_impl.HookInvocationError as shutdown_exc:
                 raise HarnessError(f"error: {shutdown_exc}") from exc
         if isinstance(exc, fixtures_impl.FixtureUnavailable):
@@ -5988,6 +6046,7 @@ def run_cli(
         if not _HOOKS_DISABLED:
             env = os.environ.copy()
             path = _env_path(env)
+            startup_succeeded = True
             _invoke_hooks(
                 (root_hooks,),
                 "startup",
@@ -6003,7 +6062,6 @@ def run_cli(
             _apply_env_path(env, path)
             os.environ.clear()
             os.environ.update(env)
-            startup_succeeded = True
 
         settings = discover_settings(root=root_path)
         apply_settings(settings)
@@ -6124,29 +6182,6 @@ def run_cli(
                     ),
                     None,
                 )
-                _invoke_hooks(
-                    hook_chain,
-                    "project_start",
-                    hooks_impl.ProjectStartContext(
-                        root=settings.root,
-                        project=project_view,
-                        previous_project=previous_project_view,
-                        kind=selection.kind,
-                        env=hooks_impl.HookEnvironment(project_env, project_path),
-                        path=project_path,
-                        debug=debug_enabled,
-                        update=update,
-                        coverage=coverage,
-                    ),
-                    project_root=selection.root,
-                    debug=debug_enabled,
-                )
-                _apply_env_path(project_env, project_path)
-                global _CURRENT_PROJECT_ENV, _CURRENT_PROJECT_VIEW, _CURRENT_HOOK_CHAIN
-                _CURRENT_PROJECT_ENV = project_env
-                _CURRENT_PROJECT_VIEW = project_view
-                _CURRENT_HOOK_CHAIN = hook_chain
-
                 project_finish_once = _HookInvocationOnce()
                 project_summary = Summary()
 
@@ -6167,6 +6202,33 @@ def run_cli(
                         project_root=selection.root,
                         debug=debug_enabled,
                     )
+
+                try:
+                    _invoke_hooks(
+                        hook_chain,
+                        "project_start",
+                        hooks_impl.ProjectStartContext(
+                            root=settings.root,
+                            project=project_view,
+                            previous_project=previous_project_view,
+                            kind=selection.kind,
+                            env=hooks_impl.HookEnvironment(project_env, project_path),
+                            path=project_path,
+                            debug=debug_enabled,
+                            update=update,
+                            coverage=coverage,
+                        ),
+                        project_root=selection.root,
+                        debug=debug_enabled,
+                    )
+                except hooks_impl.HookInvocationError:
+                    _invoke_project_finish()
+                    raise
+                _apply_env_path(project_env, project_path)
+                global _CURRENT_PROJECT_ENV, _CURRENT_PROJECT_VIEW, _CURRENT_HOOK_CHAIN
+                _CURRENT_PROJECT_ENV = project_env
+                _CURRENT_PROJECT_VIEW = project_view
+                _CURRENT_HOOK_CHAIN = hook_chain
 
                 try:
                     tests_to_run = (

--- a/src/tenzir_test/run.py
+++ b/src/tenzir_test/run.py
@@ -2723,6 +2723,42 @@ def _invoke_hooks(
     )
 
 
+@dataclasses.dataclass(slots=True)
+class _HookInvocationOnce:
+    """Invoke one lifecycle hook phase at most once.
+
+    Lifecycle cleanup must be marked as attempted before invoking user code.
+    Otherwise a failing cleanup hook can be retried by fallback paths that are
+    only meant to cover skipped cleanup.
+    """
+
+    attempted: bool = False
+
+    def invoke(
+        self,
+        hook_chain: Sequence[hooks_impl.HookSet],
+        event: hooks_impl.HookEvent,
+        context: object,
+        *,
+        reverse: bool = False,
+        project_root: Path | None = None,
+        test_path: Path | None = None,
+        debug: bool = False,
+    ) -> None:
+        if self.attempted:
+            return
+        self.attempted = True
+        _invoke_hooks(
+            hook_chain,
+            event,
+            context,
+            reverse=reverse,
+            project_root=project_root,
+            test_path=test_path,
+            debug=debug,
+        )
+
+
 _FIXTURE_LOAD_ROOTS: set[Path] = set()
 _RUNNER_LOAD_ROOTS: set[Path] = set()
 _HOOK_LOAD_CACHE: dict[Path, hooks_impl.HookSet] = {}
@@ -5738,7 +5774,7 @@ def run_fixture_mode_cli(
     root_path = Path(root or os.environ.get("TENZIR_TEST_ROOT") or Path.cwd()).resolve()
     root_hooks = hooks_impl.HookSet()
     startup_succeeded = False
-    shutdown_invoked = False
+    shutdown_once = _HookInvocationOnce()
     try:
         if not _HOOKS_DISABLED:
             try:
@@ -5770,8 +5806,7 @@ def run_fixture_mode_cli(
     apply_settings(settings)
 
     def _invoke_fixture_shutdown(exit_code: int) -> None:
-        nonlocal shutdown_invoked
-        _invoke_hooks(
+        shutdown_once.invoke(
             (root_hooks,),
             "shutdown",
             hooks_impl.ShutdownContext(
@@ -5786,7 +5821,6 @@ def run_fixture_mode_cli(
             project_root=settings.root,
             debug=debug_enabled,
         )
-        shutdown_invoked = True
 
     try:
         _set_cli_packages(list(package_dirs or []))
@@ -5851,7 +5885,7 @@ def run_fixture_mode_cli(
         _invoke_fixture_shutdown(0)
         return 0
     except BaseException as exc:
-        if startup_succeeded and not shutdown_invoked:
+        if startup_succeeded and not shutdown_once.attempted:
             try:
                 _invoke_fixture_shutdown(1)
             except hooks_impl.HookInvocationError as shutdown_exc:
@@ -5913,7 +5947,7 @@ def run_cli(
     root_hooks = hooks_impl.HookSet()
     settings: Settings | None = None
     startup_succeeded = False
-    shutdown_invoked = False
+    shutdown_once = _HookInvocationOnce()
     overall_summary = Summary()
     overall_queue_count = 0
     executed_projects: list[ProjectSelection] = []
@@ -6113,8 +6147,27 @@ def run_cli(
                 _CURRENT_PROJECT_VIEW = project_view
                 _CURRENT_HOOK_CHAIN = hook_chain
 
-                project_finish_pending = True
+                project_finish_once = _HookInvocationOnce()
                 project_summary = Summary()
+
+                def _invoke_project_finish() -> None:
+                    project_finish_once.invoke(
+                        hook_chain,
+                        "project_finish",
+                        hooks_impl.ProjectFinishContext(
+                            root=settings.root,
+                            project=project_view,
+                            next_project=_project_view(next_selection) if next_selection else None,
+                            kind=selection.kind,
+                            summary=_summary_view(project_summary),
+                            interrupted=interrupted or interrupt_requested(),
+                            debug=debug_enabled,
+                        ),
+                        reverse=True,
+                        project_root=selection.root,
+                        debug=debug_enabled,
+                    )
+
                 try:
                     tests_to_run = (
                         selection.selectors if not selection.run_all else [selection.root]
@@ -6122,29 +6175,7 @@ def run_cli(
 
                     if purge:
                         project_summary = Summary()
-                        _invoke_hooks(
-                            hook_chain,
-                            "project_finish",
-                            hooks_impl.ProjectFinishContext(
-                                root=settings.root,
-                                project=project_view,
-                                next_project=_project_view(next_selection)
-                                if next_selection
-                                else None,
-                                kind=selection.kind,
-                                summary=_summary_view(project_summary),
-                                interrupted=interrupted or interrupt_requested(),
-                                debug=debug_enabled,
-                            ),
-                            reverse=True,
-                            project_root=selection.root,
-                            debug=debug_enabled,
-                        )
-                        project_finish_pending = False
-                        previous_project_view = project_view
-                        _CURRENT_PROJECT_ENV = None
-                        _CURRENT_PROJECT_VIEW = None
-                        _CURRENT_HOOK_CHAIN = tuple()
+                        _invoke_project_finish()
                         continue
 
                     collected_paths: set[Path] = set()
@@ -6279,29 +6310,7 @@ def run_cli(
                                 queue_size=project_queue_size,
                             )
                         )
-                        _invoke_hooks(
-                            hook_chain,
-                            "project_finish",
-                            hooks_impl.ProjectFinishContext(
-                                root=settings.root,
-                                project=project_view,
-                                next_project=_project_view(next_selection)
-                                if next_selection
-                                else None,
-                                kind=selection.kind,
-                                summary=_summary_view(project_summary),
-                                interrupted=interrupted or interrupt_requested(),
-                                debug=debug_enabled,
-                            ),
-                            reverse=True,
-                            project_root=selection.root,
-                            debug=debug_enabled,
-                        )
-                        project_finish_pending = False
-                        previous_project_view = project_view
-                        _CURRENT_PROJECT_ENV = None
-                        _CURRENT_PROJECT_VIEW = None
-                        _CURRENT_HOOK_CHAIN = tuple()
+                        _invoke_project_finish()
                         continue
 
                     os.environ["TENZIR_EXEC__DUMP_DIAGNOSTICS"] = "true"
@@ -6431,51 +6440,13 @@ def run_cli(
                             queue_size=project_queue_size,
                         )
                     )
-                    _invoke_hooks(
-                        hook_chain,
-                        "project_finish",
-                        hooks_impl.ProjectFinishContext(
-                            root=settings.root,
-                            project=project_view,
-                            next_project=_project_view(next_selection) if next_selection else None,
-                            kind=selection.kind,
-                            summary=_summary_view(project_summary),
-                            interrupted=interrupted or interrupt_requested(),
-                            debug=debug_enabled,
-                        ),
-                        reverse=True,
-                        project_root=selection.root,
-                        debug=debug_enabled,
-                    )
-                    project_finish_pending = False
-                    previous_project_view = project_view
-                    _CURRENT_PROJECT_ENV = None
-                    _CURRENT_PROJECT_VIEW = None
-                    _CURRENT_HOOK_CHAIN = tuple()
+                    _invoke_project_finish()
 
                     if interrupt_requested():
                         break
 
                 finally:
-                    if project_finish_pending:
-                        _invoke_hooks(
-                            hook_chain,
-                            "project_finish",
-                            hooks_impl.ProjectFinishContext(
-                                root=settings.root,
-                                project=project_view,
-                                next_project=_project_view(next_selection)
-                                if next_selection
-                                else None,
-                                kind=selection.kind,
-                                summary=_summary_view(project_summary),
-                                interrupted=interrupted or interrupt_requested(),
-                                debug=debug_enabled,
-                            ),
-                            reverse=True,
-                            project_root=selection.root,
-                            debug=debug_enabled,
-                        )
+                    _invoke_project_finish()
                     previous_project_view = project_view
                     _CURRENT_PROJECT_ENV = None
                     _CURRENT_PROJECT_VIEW = None
@@ -6485,8 +6456,7 @@ def run_cli(
             engine_state.refresh()
 
             def _finish_result(result: ExecutionResult) -> ExecutionResult:
-                nonlocal shutdown_invoked
-                _invoke_hooks(
+                shutdown_once.invoke(
                     (root_hooks,),
                     "shutdown",
                     hooks_impl.ShutdownContext(
@@ -6503,7 +6473,6 @@ def run_cli(
                     project_root=settings.root,
                     debug=debug_enabled,
                 )
-                shutdown_invoked = True
                 return result
 
             interrupted = interrupted or interrupt_requested()
@@ -6558,10 +6527,10 @@ def run_cli(
             )
 
     except Exception as exc:
-        if startup_succeeded and not shutdown_invoked:
+        if startup_succeeded and not shutdown_once.attempted:
             shutdown_root = settings.root if settings is not None else root_path
             try:
-                _invoke_hooks(
+                shutdown_once.invoke(
                     (root_hooks,),
                     "shutdown",
                     hooks_impl.ShutdownContext(

--- a/src/tenzir_test/run.py
+++ b/src/tenzir_test/run.py
@@ -5768,55 +5768,6 @@ def run_fixture_mode_cli(
 
     settings = discover_settings(root=root_path)
     apply_settings(settings)
-    _set_cli_packages(list(package_dirs or []))
-
-    try:
-        _load_project_fixtures(ROOT, expose_namespace=True)
-    except RuntimeError as exc:
-        raise HarnessError(f"error: {exc}") from exc
-
-    try:
-        fixture_specs = _normalize_cli_fixture_specs(fixtures)
-    except ValueError as exc:
-        raise HarnessError(f"error: {exc}") from exc
-
-    fixture_test = ROOT / ".fixture-mode"
-    env, config_args = get_test_env_and_config_args(fixture_test)
-
-    package_dir_candidates: list[str] = []
-    package_root = packages.find_package_root(fixture_test)
-    if package_root is not None:
-        env["TENZIR_PACKAGE_ROOT"] = str(package_root)
-        package_dir_candidates.append(str(package_root))
-    for cli_path in _get_cli_packages():
-        package_dir_candidates.extend(_expand_package_dirs(cli_path))
-    if package_dir_candidates:
-        merged_dirs = _deduplicate_package_dirs(package_dir_candidates)
-        env["TENZIR_PACKAGE_DIRS"] = ",".join(merged_dirs)
-        config_args.append(f"--package-dirs={','.join(merged_dirs)}")
-
-    for spec in fixture_specs:
-        try:
-            fixtures_impl.acquire_fixture(spec.name)
-        except ValueError as exc:
-            raise HarnessError(f"error: {exc}") from exc
-
-    try:
-        fixture_options = _build_fixture_options(fixture_specs)
-    except ValueError as exc:
-        raise HarnessError(f"error: {exc}") from exc
-    context_token = fixtures_impl.push_context(
-        fixtures_impl.FixtureContext(
-            test=fixture_test,
-            config={"fixtures": fixture_specs},
-            coverage=False,
-            env=env,
-            config_args=tuple(config_args),
-            tenzir_binary=TENZIR_BINARY,
-            tenzir_node_binary=TENZIR_NODE_BINARY,
-            fixture_options=fixture_options,
-        )
-    )
 
     def _invoke_fixture_shutdown(exit_code: int) -> None:
         nonlocal shutdown_invoked
@@ -5838,11 +5789,67 @@ def run_fixture_mode_cli(
         shutdown_invoked = True
 
     try:
-        with fixtures_impl.activate(fixture_specs) as fixture_env:
-            env.update(fixture_env)
-            _apply_fixture_env(env, fixture_specs)
-            _print_fixture_env_lines(fixture_env)
-            _wait_for_fixture_shutdown()
+        _set_cli_packages(list(package_dirs or []))
+
+        try:
+            _load_project_fixtures(ROOT, expose_namespace=True)
+        except RuntimeError as exc:
+            raise HarnessError(f"error: {exc}") from exc
+
+        try:
+            fixture_specs = _normalize_cli_fixture_specs(fixtures)
+        except ValueError as exc:
+            raise HarnessError(f"error: {exc}") from exc
+
+        fixture_test = ROOT / ".fixture-mode"
+        env, config_args = get_test_env_and_config_args(fixture_test)
+
+        package_dir_candidates: list[str] = []
+        package_root = packages.find_package_root(fixture_test)
+        if package_root is not None:
+            env["TENZIR_PACKAGE_ROOT"] = str(package_root)
+            package_dir_candidates.append(str(package_root))
+        for cli_path in _get_cli_packages():
+            package_dir_candidates.extend(_expand_package_dirs(cli_path))
+        if package_dir_candidates:
+            merged_dirs = _deduplicate_package_dirs(package_dir_candidates)
+            env["TENZIR_PACKAGE_DIRS"] = ",".join(merged_dirs)
+            config_args.append(f"--package-dirs={','.join(merged_dirs)}")
+
+        for spec in fixture_specs:
+            try:
+                fixtures_impl.acquire_fixture(spec.name)
+            except ValueError as exc:
+                raise HarnessError(f"error: {exc}") from exc
+
+        try:
+            fixture_options = _build_fixture_options(fixture_specs)
+        except ValueError as exc:
+            raise HarnessError(f"error: {exc}") from exc
+        context_token = fixtures_impl.push_context(
+            fixtures_impl.FixtureContext(
+                test=fixture_test,
+                config={"fixtures": fixture_specs},
+                coverage=False,
+                env=env,
+                config_args=tuple(config_args),
+                tenzir_binary=TENZIR_BINARY,
+                tenzir_node_binary=TENZIR_NODE_BINARY,
+                fixture_options=fixture_options,
+            )
+        )
+        try:
+            with fixtures_impl.activate(fixture_specs) as fixture_env:
+                env.update(fixture_env)
+                _apply_fixture_env(env, fixture_specs)
+                _print_fixture_env_lines(fixture_env)
+                _wait_for_fixture_shutdown()
+        finally:
+            fixtures_impl.pop_context(context_token)
+            cleanup_test_tmp_dir(env.get(TEST_TMP_ENV_VAR))
+
+        _invoke_fixture_shutdown(0)
+        return 0
     except BaseException as exc:
         if startup_succeeded and not shutdown_invoked:
             try:
@@ -5851,17 +5858,9 @@ def run_fixture_mode_cli(
                 raise HarnessError(f"error: {shutdown_exc}") from exc
         if isinstance(exc, fixtures_impl.FixtureUnavailable):
             _raise_fixture_unavailable_harness_error(exc)
+        if isinstance(exc, hooks_impl.HookInvocationError):
+            raise HarnessError(f"error: {exc}") from exc
         raise
-    finally:
-        fixtures_impl.pop_context(context_token)
-        cleanup_test_tmp_dir(env.get(TEST_TMP_ENV_VAR))
-
-    try:
-        _invoke_fixture_shutdown(0)
-    except hooks_impl.HookInvocationError as exc:
-        raise HarnessError(f"error: {exc}") from exc
-
-    return 0
 
 
 def run_cli(

--- a/src/tenzir_test/run.py
+++ b/src/tenzir_test/run.py
@@ -756,6 +756,14 @@ def _exception_is_interrupt(exc: BaseException) -> bool:
     return False
 
 
+def _exception_exit_code(exc: BaseException) -> int:
+    if _exception_is_interrupt(exc) or interrupt_requested():
+        return 130
+    if isinstance(exc, SystemExit) and isinstance(exc.code, int):
+        return exc.code
+    return 1
+
+
 _CURRENT_RETRY_CONTEXT = threading.local()
 _CURRENT_SUITE_CONTEXT = threading.local()
 _CURRENT_ASSERTION_CHECK_CONTEXT = threading.local()
@@ -2644,7 +2652,7 @@ def _load_project_hooks(root: Path) -> hooks_impl.HookSet:
                 _CLI_LOGGER.debug("loading hooks from %s", hooks_file)
                 _import_module_from_path(module_base, hooks_file)
             hook_set = loading_set
-    except Exception as exc:
+    except BaseException as exc:
         raise RuntimeError(f"failed to load hooks from {resolved_root}: {exc}") from exc
     _HOOK_LOAD_CACHE[resolved_root] = hook_set
     return hook_set
@@ -2913,9 +2921,15 @@ def get_test_env_and_config_args(
     if node_config_file.exists():
         env["TENZIR_NODE_CONFIG"] = str(node_config_file)
     if TENZIR_BINARY:
-        env["TENZIR_BINARY"] = shlex.join(TENZIR_BINARY)
+        if _CURRENT_PROJECT_ENV is None:
+            env["TENZIR_BINARY"] = shlex.join(TENZIR_BINARY)
+        else:
+            env.setdefault("TENZIR_BINARY", shlex.join(TENZIR_BINARY))
     if TENZIR_NODE_BINARY:
-        env["TENZIR_NODE_BINARY"] = shlex.join(TENZIR_NODE_BINARY)
+        if _CURRENT_PROJECT_ENV is None:
+            env["TENZIR_NODE_BINARY"] = shlex.join(TENZIR_NODE_BINARY)
+        else:
+            env.setdefault("TENZIR_NODE_BINARY", shlex.join(TENZIR_NODE_BINARY))
     env["TENZIR_TEST_ROOT"] = str(ROOT)
     tmp_dir = _create_test_tmp_dir(test)
     env[TEST_TMP_ENV_VAR] = str(tmp_dir)
@@ -4920,7 +4934,7 @@ class Worker:
                 if interrupt_requested():
                     break
             return result
-        except Exception as exc:  # pragma: no cover - defensive logging
+        except BaseException as exc:  # pragma: no cover - defensive logging
             self._exception = exc
             if self._result is None:
                 self._result = Summary()
@@ -5572,39 +5586,41 @@ class Worker:
                 update=self._update,
                 coverage=self._coverage,
             )
-            _invoke_hooks(
-                self._hook_chain,
-                "test_finish",
-                finish_ctx,
-                reverse=True,
-                project_root=self._hook_root,
-                test_path=test_path,
-                debug=self._debug,
-            )
-            _invoke_hooks(
-                self._hook_chain,
-                "test_failure",
-                hooks_impl.TestFailureContext(
-                    root=finish_ctx.root,
-                    project=finish_ctx.project,
-                    test=finish_ctx.test,
-                    runner=finish_ctx.runner,
-                    reason=finish_ctx.reason,
-                    attempts=finish_ctx.attempts,
-                    duration=finish_ctx.duration,
-                    fixtures=finish_ctx.fixtures,
-                    suite=finish_ctx.suite,
-                    tmp_dir=finish_ctx.tmp_dir,
-                    update=finish_ctx.update,
-                    coverage=finish_ctx.coverage,
-                ),
-                reverse=True,
-                project_root=self._hook_root,
-                test_path=test_path,
-                debug=self._debug,
-            )
-            for path in deferred_tmp_dirs:
-                _cleanup_test_tmp_dir_now(path)
+            try:
+                _invoke_hooks(
+                    self._hook_chain,
+                    "test_finish",
+                    finish_ctx,
+                    reverse=True,
+                    project_root=self._hook_root,
+                    test_path=test_path,
+                    debug=self._debug,
+                )
+                _invoke_hooks(
+                    self._hook_chain,
+                    "test_failure",
+                    hooks_impl.TestFailureContext(
+                        root=finish_ctx.root,
+                        project=finish_ctx.project,
+                        test=finish_ctx.test,
+                        runner=finish_ctx.runner,
+                        reason=finish_ctx.reason,
+                        attempts=finish_ctx.attempts,
+                        duration=finish_ctx.duration,
+                        fixtures=finish_ctx.fixtures,
+                        suite=finish_ctx.suite,
+                        tmp_dir=finish_ctx.tmp_dir,
+                        update=finish_ctx.update,
+                        coverage=finish_ctx.coverage,
+                    ),
+                    reverse=True,
+                    project_root=self._hook_root,
+                    test_path=test_path,
+                    debug=self._debug,
+                )
+            finally:
+                for path in deferred_tmp_dirs:
+                    _cleanup_test_tmp_dir_now(path)
             return True
 
         summary.total += 1
@@ -5639,40 +5655,42 @@ class Worker:
             update=self._update,
             coverage=self._coverage,
         )
-        _invoke_hooks(
-            self._hook_chain,
-            "test_finish",
-            finish_ctx,
-            reverse=True,
-            project_root=self._hook_root,
-            test_path=test_path,
-            debug=self._debug,
-        )
-        if outcome_name == "failed":
+        try:
             _invoke_hooks(
                 self._hook_chain,
-                "test_failure",
-                hooks_impl.TestFailureContext(
-                    root=finish_ctx.root,
-                    project=finish_ctx.project,
-                    test=finish_ctx.test,
-                    runner=finish_ctx.runner,
-                    reason=finish_ctx.reason,
-                    attempts=finish_ctx.attempts,
-                    duration=finish_ctx.duration,
-                    fixtures=finish_ctx.fixtures,
-                    suite=finish_ctx.suite,
-                    tmp_dir=finish_ctx.tmp_dir,
-                    update=finish_ctx.update,
-                    coverage=finish_ctx.coverage,
-                ),
+                "test_finish",
+                finish_ctx,
                 reverse=True,
                 project_root=self._hook_root,
                 test_path=test_path,
                 debug=self._debug,
             )
-        for path in deferred_tmp_dirs:
-            _cleanup_test_tmp_dir_now(path)
+            if outcome_name == "failed":
+                _invoke_hooks(
+                    self._hook_chain,
+                    "test_failure",
+                    hooks_impl.TestFailureContext(
+                        root=finish_ctx.root,
+                        project=finish_ctx.project,
+                        test=finish_ctx.test,
+                        runner=finish_ctx.runner,
+                        reason=finish_ctx.reason,
+                        attempts=finish_ctx.attempts,
+                        duration=finish_ctx.duration,
+                        fixtures=finish_ctx.fixtures,
+                        suite=finish_ctx.suite,
+                        tmp_dir=finish_ctx.tmp_dir,
+                        update=finish_ctx.update,
+                        coverage=finish_ctx.coverage,
+                    ),
+                    reverse=True,
+                    project_root=self._hook_root,
+                    test_path=test_path,
+                    debug=self._debug,
+                )
+        finally:
+            for path in deferred_tmp_dirs:
+                _cleanup_test_tmp_dir_now(path)
         return final_interrupted or interrupt_requested()
 
 
@@ -5820,8 +5838,8 @@ def _print_fixture_env_lines(env: Mapping[str, str]) -> None:
         print(f"{INFO} fixture environment is active; press Ctrl+C to stop")
 
 
-def _wait_for_fixture_shutdown() -> None:
-    """Block until SIGINT/SIGTERM is received, then return."""
+def _wait_for_fixture_shutdown() -> bool:
+    """Block until SIGINT/SIGTERM is received and return whether interrupted."""
 
     stop_event = threading.Event()
     previous = {
@@ -5838,8 +5856,9 @@ def _wait_for_fixture_shutdown() -> None:
     try:
         while not stop_event.wait(0.25):
             continue
+        return True
     except KeyboardInterrupt:  # pragma: no cover - defensive fallback
-        pass
+        return True
     finally:
         signal.signal(signal.SIGINT, previous[signal.SIGINT])
         signal.signal(signal.SIGTERM, previous[signal.SIGTERM])
@@ -5901,7 +5920,7 @@ def run_fixture_mode_cli(
             _apply_env_path(env, path)
             os.environ.clear()
             os.environ.update(env)
-    except hooks_impl.HookInvocationError as exc:
+    except BaseException as exc:
         if startup_succeeded and not shutdown_once.attempted:
             try:
                 shutdown_once.invoke(
@@ -5909,8 +5928,8 @@ def run_fixture_mode_cli(
                     "shutdown",
                     hooks_impl.ShutdownContext(
                         root=root_path,
-                        exit_code=1,
-                        interrupted=False,
+                        exit_code=_exception_exit_code(exc),
+                        interrupted=_exception_is_interrupt(exc) or interrupt_requested(),
                         summary=hooks_impl.SummaryView(failed=0, total=0, skipped=0),
                         project_results=tuple(),
                         debug=debug_enabled,
@@ -5920,19 +5939,28 @@ def run_fixture_mode_cli(
                     debug=debug_enabled,
                 )
             except hooks_impl.HookInvocationError as shutdown_exc:
-                raise HarnessError(f"error: {exc}; additionally, {shutdown_exc}") from exc
-        raise HarnessError(f"error: {exc}") from exc
+                if isinstance(exc, hooks_impl.HookInvocationError):
+                    raise HarnessError(f"error: {exc}; additionally, {shutdown_exc}") from exc
+                raise HarnessError(f"error: {shutdown_exc}") from exc
+        if isinstance(exc, hooks_impl.HookInvocationError):
+            raise HarnessError(f"error: {exc}") from exc
+        raise
 
     settings: Settings | None = None
 
-    def _invoke_fixture_shutdown(exit_code: int, *, shutdown_root: Path) -> None:
+    def _invoke_fixture_shutdown(
+        exit_code: int,
+        *,
+        shutdown_root: Path,
+        interrupted: bool = False,
+    ) -> None:
         shutdown_once.invoke(
             (root_hooks,),
             "shutdown",
             hooks_impl.ShutdownContext(
                 root=shutdown_root,
                 exit_code=exit_code,
-                interrupted=False,
+                interrupted=interrupted,
                 summary=hooks_impl.SummaryView(failed=0, total=0, skipped=0),
                 project_results=tuple(),
                 debug=debug_enabled,
@@ -5999,18 +6027,26 @@ def run_fixture_mode_cli(
                 env.update(fixture_env)
                 _apply_fixture_env(env, fixture_specs)
                 _print_fixture_env_lines(fixture_env)
-                _wait_for_fixture_shutdown()
+                fixture_interrupted = bool(_wait_for_fixture_shutdown())
         finally:
             fixtures_impl.pop_context(context_token)
             cleanup_test_tmp_dir(env.get(TEST_TMP_ENV_VAR))
 
-        _invoke_fixture_shutdown(0, shutdown_root=settings.root)
+        _invoke_fixture_shutdown(
+            0,
+            shutdown_root=settings.root,
+            interrupted=fixture_interrupted,
+        )
         return 0
     except BaseException as exc:
         if startup_succeeded and not shutdown_once.attempted:
             try:
                 shutdown_root = settings.root if settings is not None else root_path
-                _invoke_fixture_shutdown(1, shutdown_root=shutdown_root)
+                _invoke_fixture_shutdown(
+                    _exception_exit_code(exc),
+                    shutdown_root=shutdown_root,
+                    interrupted=_exception_is_interrupt(exc) or interrupt_requested(),
+                )
             except hooks_impl.HookInvocationError as shutdown_exc:
                 raise HarnessError(f"error: {shutdown_exc}") from exc
         if isinstance(exc, fixtures_impl.FixtureUnavailable):
@@ -6687,7 +6723,7 @@ def run_cli(
                 )
             )
 
-    except Exception as exc:
+    except BaseException as exc:
         if startup_succeeded and not shutdown_once.attempted:
             shutdown_root = settings.root if settings is not None else root_path
             try:
@@ -6696,8 +6732,8 @@ def run_cli(
                     "shutdown",
                     hooks_impl.ShutdownContext(
                         root=shutdown_root,
-                        exit_code=130 if interrupt_requested() else 1,
-                        interrupted=interrupt_requested(),
+                        exit_code=_exception_exit_code(exc),
+                        interrupted=_exception_is_interrupt(exc) or interrupt_requested(),
                         summary=_summary_view(overall_summary),
                         project_results=tuple(
                             _project_result_view(item) for item in project_results

--- a/src/tenzir_test/run.py
+++ b/src/tenzir_test/run.py
@@ -4527,6 +4527,7 @@ class Worker:
         suite_queue_state: SuiteQueueState | None = None,
         hook_chain: Sequence[hooks_impl.HookSet] = (),
         project_view: hooks_impl.ProjectView | None = None,
+        hook_root: Path | None = None,
     ) -> None:
         self._queue = queue
         self._result: Summary | None = None
@@ -4548,7 +4549,10 @@ class Worker:
         self._run_skipped_match_count = 0
         self._run_skipped_match_count_lock = threading.Lock()
         self._hook_chain = tuple(hook_chain)
-        self._project_view = project_view or hooks_impl.ProjectView(root=ROOT, kind="root")
+        self._hook_root = hook_root or ROOT
+        self._project_view = project_view or hooks_impl.ProjectView(
+            root=self._hook_root, kind="root"
+        )
         self._thread = threading.Thread(target=self._work)
 
     def __del__(self) -> None:
@@ -4676,7 +4680,7 @@ class Worker:
             self._hook_chain,
             "test_finish",
             hooks_impl.TestFinishContext(
-                root=ROOT,
+                root=self._hook_root,
                 project=self._project_view,
                 test=test_item.path,
                 runner=test_item.runner.name,
@@ -4691,7 +4695,7 @@ class Worker:
                 coverage=self._coverage,
             ),
             reverse=True,
-            project_root=ROOT,
+            project_root=self._hook_root,
             test_path=test_item.path,
             debug=self._debug,
         )
@@ -4762,7 +4766,7 @@ class Worker:
                 self._hook_chain,
                 "test_finish",
                 hooks_impl.TestFinishContext(
-                    root=ROOT,
+                    root=self._hook_root,
                     project=self._project_view,
                     test=test_item.path,
                     runner=test_item.runner.name,
@@ -4780,7 +4784,7 @@ class Worker:
                     coverage=self._coverage,
                 ),
                 reverse=True,
-                project_root=ROOT,
+                project_root=self._hook_root,
                 test_path=test_item.path,
                 debug=self._debug,
             )
@@ -5273,7 +5277,7 @@ class Worker:
             summary.failed += 1
             summary.failed_paths.append(rel_path)
             finish_ctx = hooks_impl.TestFinishContext(
-                root=ROOT,
+                root=self._hook_root,
                 project=self._project_view,
                 test=test_path,
                 runner=runner.name,
@@ -5292,7 +5296,7 @@ class Worker:
                 "test_finish",
                 finish_ctx,
                 reverse=True,
-                project_root=ROOT,
+                project_root=self._hook_root,
                 test_path=test_path,
                 debug=self._debug,
             )
@@ -5314,7 +5318,7 @@ class Worker:
                     coverage=finish_ctx.coverage,
                 ),
                 reverse=True,
-                project_root=ROOT,
+                project_root=self._hook_root,
                 test_path=test_path,
                 debug=self._debug,
             )
@@ -5341,7 +5345,7 @@ class Worker:
             self._hook_chain,
             "test_start",
             hooks_impl.TestStartContext(
-                root=ROOT,
+                root=self._hook_root,
                 project=self._project_view,
                 test=test_path,
                 runner=runner.name,
@@ -5351,7 +5355,7 @@ class Worker:
                 coverage=self._coverage,
                 attempt_limit=max_attempts,
             ),
-            project_root=ROOT,
+            project_root=self._hook_root,
             test_path=test_path,
             debug=self._debug,
         )
@@ -5493,7 +5497,7 @@ class Worker:
             outcome_name = "failed"
         finish_reason: str | None = _INTERRUPTED_NOTICE if final_interrupted else None
         finish_ctx = hooks_impl.TestFinishContext(
-            root=ROOT,
+            root=self._hook_root,
             project=self._project_view,
             test=test_path,
             runner=runner.name,
@@ -5512,7 +5516,7 @@ class Worker:
             "test_finish",
             finish_ctx,
             reverse=True,
-            project_root=ROOT,
+            project_root=self._hook_root,
             test_path=test_path,
             debug=self._debug,
         )
@@ -5535,7 +5539,7 @@ class Worker:
                     coverage=finish_ctx.coverage,
                 ),
                 reverse=True,
-                project_root=ROOT,
+                project_root=self._hook_root,
                 test_path=test_path,
                 debug=self._debug,
             )
@@ -5911,6 +5915,10 @@ def run_cli(
     settings: Settings | None = None
     startup_succeeded = False
     shutdown_invoked = False
+    overall_summary = Summary()
+    overall_queue_count = 0
+    executed_projects: list[ProjectSelection] = []
+    project_results: list[ProjectResult] = []
 
     try:
         debug_enabled = bool(debug or _default_debug_logging)
@@ -6026,8 +6034,8 @@ def run_cli(
 
             overall_summary = Summary()
             overall_queue_count = 0
-            executed_projects: list[ProjectSelection] = []
-            project_results: list[ProjectResult] = []
+            executed_projects = []
+            project_results = []
             printed_projects = 0
             interrupted = False
             plan_projects = list(plan.projects())
@@ -6359,6 +6367,7 @@ def run_cli(
                             suite_queue_state=suite_queue_state,
                             hook_chain=hook_chain,
                             project_view=project_view,
+                            hook_root=settings.root,
                         )
                         for _ in range(jobs)
                     ]
@@ -6560,8 +6569,10 @@ def run_cli(
                         root=shutdown_root,
                         exit_code=130 if interrupt_requested() else 1,
                         interrupted=interrupt_requested(),
-                        summary=hooks_impl.SummaryView(failed=0, total=0, skipped=0),
-                        project_results=tuple(),
+                        summary=_summary_view(overall_summary),
+                        project_results=tuple(
+                            _project_result_view(item) for item in project_results
+                        ),
                         debug=debug_enabled,
                     ),
                     reverse=True,

--- a/src/tenzir_test/run.py
+++ b/src/tenzir_test/run.py
@@ -5550,6 +5550,55 @@ class Worker:
         if attempts == 0 and final_interrupted:
             # The test never started an execution attempt (for example, work
             # was cancelled after an interrupt), so do not count it as failed.
+            # Still balance the hook lifecycle because test_start already ran.
+            finish_ctx = hooks_impl.TestFinishContext(
+                root=self._hook_root,
+                project=self._project_view,
+                test=test_path,
+                runner=runner.name,
+                outcome="failed",
+                reason=_INTERRUPTED_NOTICE,
+                attempts=0,
+                duration=duration,
+                fixtures=_fixture_views(fixtures),
+                suite=suite_view,
+                tmp_dir=tmp_dir,
+                update=self._update,
+                coverage=self._coverage,
+            )
+            _invoke_hooks(
+                self._hook_chain,
+                "test_finish",
+                finish_ctx,
+                reverse=True,
+                project_root=self._hook_root,
+                test_path=test_path,
+                debug=self._debug,
+            )
+            _invoke_hooks(
+                self._hook_chain,
+                "test_failure",
+                hooks_impl.TestFailureContext(
+                    root=finish_ctx.root,
+                    project=finish_ctx.project,
+                    test=finish_ctx.test,
+                    runner=finish_ctx.runner,
+                    reason=finish_ctx.reason,
+                    attempts=finish_ctx.attempts,
+                    duration=finish_ctx.duration,
+                    fixtures=finish_ctx.fixtures,
+                    suite=finish_ctx.suite,
+                    tmp_dir=finish_ctx.tmp_dir,
+                    update=finish_ctx.update,
+                    coverage=finish_ctx.coverage,
+                ),
+                reverse=True,
+                project_root=self._hook_root,
+                test_path=test_path,
+                debug=self._debug,
+            )
+            for path in deferred_tmp_dirs:
+                _cleanup_test_tmp_dir_now(path)
             return True
 
         summary.total += 1

--- a/src/tenzir_test/run.py
+++ b/src/tenzir_test/run.py
@@ -5723,21 +5723,25 @@ def run_fixture_mode_cli(
     global _HOOKS_DISABLED
     _HOOKS_DISABLED = _hooks_disabled(no_hooks)
     root_path = Path(root or os.environ.get("TENZIR_TEST_ROOT") or Path.cwd()).resolve()
-    if not _HOOKS_DISABLED:
-        try:
-            root_hooks = _load_project_hooks(root_path)
-        except RuntimeError as exc:
-            raise HarnessError(f"error: {exc}") from exc
-        env = os.environ.copy()
-        _invoke_hooks(
-            (root_hooks,),
-            "startup",
-            hooks_impl.StartupContext(root=root_path, env=env, debug=debug_enabled),
-            project_root=root_path,
-            debug=debug_enabled,
-        )
-        os.environ.clear()
-        os.environ.update(env)
+    root_hooks = hooks_impl.HookSet()
+    try:
+        if not _HOOKS_DISABLED:
+            try:
+                root_hooks = _load_project_hooks(root_path)
+            except RuntimeError as exc:
+                raise HarnessError(f"error: {exc}") from exc
+            env = os.environ.copy()
+            _invoke_hooks(
+                (root_hooks,),
+                "startup",
+                hooks_impl.StartupContext(root=root_path, env=env, debug=debug_enabled),
+                project_root=root_path,
+                debug=debug_enabled,
+            )
+            os.environ.clear()
+            os.environ.update(env)
+    except hooks_impl.HookInvocationError as exc:
+        raise HarnessError(f"error: {exc}") from exc
 
     settings = discover_settings(root=root_path)
     apply_settings(settings)
@@ -5801,6 +5805,25 @@ def run_fixture_mode_cli(
     finally:
         fixtures_impl.pop_context(context_token)
         cleanup_test_tmp_dir(env.get(TEST_TMP_ENV_VAR))
+
+    try:
+        _invoke_hooks(
+            (root_hooks,),
+            "shutdown",
+            hooks_impl.ShutdownContext(
+                root=settings.root,
+                exit_code=0,
+                interrupted=False,
+                summary=hooks_impl.SummaryView(failed=0, total=0, skipped=0),
+                project_results=tuple(),
+                debug=debug_enabled,
+            ),
+            reverse=True,
+            project_root=settings.root,
+            debug=debug_enabled,
+        )
+    except hooks_impl.HookInvocationError as exc:
+        raise HarnessError(f"error: {exc}") from exc
 
     return 0
 
@@ -6036,7 +6059,27 @@ def run_cli(
                 tests_to_run = selection.selectors if not selection.run_all else [selection.root]
 
                 if purge:
+                    project_summary = Summary()
+                    _invoke_hooks(
+                        hook_chain,
+                        "project_finish",
+                        hooks_impl.ProjectFinishContext(
+                            root=settings.root,
+                            project=project_view,
+                            next_project=_project_view(next_selection) if next_selection else None,
+                            kind=selection.kind,
+                            summary=_summary_view(project_summary),
+                            interrupted=interrupted or interrupt_requested(),
+                            debug=debug_enabled,
+                        ),
+                        reverse=True,
+                        project_root=selection.root,
+                        debug=debug_enabled,
+                    )
                     previous_project_view = project_view
+                    _CURRENT_PROJECT_ENV = None
+                    _CURRENT_PROJECT_VIEW = None
+                    _CURRENT_HOOK_CHAIN = tuple()
                     continue
 
                 collected_paths: set[Path] = set()

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -117,6 +117,87 @@ def test_startup_hook_rejects_env_path_mutation(tmp_path: Path, monkeypatch) -> 
         _restore_runtime(original_settings, original_root)
 
 
+def test_run_cli_shutdown_runs_after_startup_base_exception(tmp_path: Path) -> None:
+    original_settings = run._settings  # type: ignore[attr-defined]
+    original_root = run.ROOT
+    (tmp_path / "tests").mkdir()
+    log_path = tmp_path / "shutdown.log"
+    hooks_dir = tmp_path / "hooks"
+    hooks_dir.mkdir()
+    (hooks_dir / "__init__.py").write_text(
+        "from tenzir_test import hooks\n"
+        "@hooks.startup\n"
+        "def startup(ctx):\n"
+        "    raise SystemExit(7)\n"
+        "@hooks.shutdown\n"
+        "def shutdown(ctx):\n"
+        f"    open({str(log_path)!r}, 'w').write(f'{{ctx.exit_code}}:{{ctx.interrupted}}')\n",
+        encoding="utf-8",
+    )
+    run._HOOK_LOAD_CACHE.clear()  # type: ignore[attr-defined]
+
+    try:
+        with pytest.raises(run.HarnessError, match="hook startup startup failed"):
+            run.execute(root=tmp_path, tests=[])
+    finally:
+        run._HOOK_LOAD_CACHE.clear()  # type: ignore[attr-defined]
+        _restore_runtime(original_settings, original_root)
+
+    assert log_path.read_text(encoding="utf-8") == "1:False"
+
+
+def test_fixture_mode_shutdown_runs_after_startup_base_exception(tmp_path: Path) -> None:
+    original_settings = run._settings  # type: ignore[attr-defined]
+    original_root = run.ROOT
+    (tmp_path / "tests").mkdir()
+    log_path = tmp_path / "fixture-shutdown.log"
+    hooks_dir = tmp_path / "hooks"
+    hooks_dir.mkdir()
+    (hooks_dir / "__init__.py").write_text(
+        "from tenzir_test import hooks\n"
+        "@hooks.startup\n"
+        "def startup(ctx):\n"
+        "    raise SystemExit(9)\n"
+        "@hooks.shutdown\n"
+        "def shutdown(ctx):\n"
+        f"    open({str(log_path)!r}, 'w').write(f'{{ctx.exit_code}}:{{ctx.interrupted}}')\n",
+        encoding="utf-8",
+    )
+    run._HOOK_LOAD_CACHE.clear()  # type: ignore[attr-defined]
+
+    try:
+        with pytest.raises(run.HarnessError, match="hook startup startup failed"):
+            run.run_fixture_mode_cli(
+                root=tmp_path,
+                package_dirs=None,
+                fixtures=("unknown",),
+                debug=False,
+                keep_tmp_dirs=False,
+            )
+    finally:
+        run._HOOK_LOAD_CACHE.clear()  # type: ignore[attr-defined]
+        _restore_runtime(original_settings, original_root)
+
+    assert log_path.read_text(encoding="utf-8") == "1:False"
+
+
+def test_project_hook_load_base_exception_is_wrapped(tmp_path: Path) -> None:
+    original_settings = run._settings  # type: ignore[attr-defined]
+    original_root = run.ROOT
+    (tmp_path / "tests").mkdir()
+    hooks_dir = tmp_path / "hooks"
+    hooks_dir.mkdir()
+    (hooks_dir / "__init__.py").write_text("raise SystemExit(4)\n", encoding="utf-8")
+    run._HOOK_LOAD_CACHE.clear()  # type: ignore[attr-defined]
+
+    try:
+        with pytest.raises(run.HarnessError, match="failed to load hooks"):
+            run.execute(root=tmp_path, tests=[])
+    finally:
+        run._HOOK_LOAD_CACHE.clear()  # type: ignore[attr-defined]
+        _restore_runtime(original_settings, original_root)
+
+
 def test_no_hooks_disables_startup_hook(tmp_path: Path, monkeypatch) -> None:
     original_settings = run._settings  # type: ignore[attr-defined]
     original_root = run.ROOT
@@ -216,6 +297,45 @@ def test_fixture_mode_invokes_shutdown_hooks(tmp_path: Path, monkeypatch) -> Non
 
     assert exit_code == 0
     assert log_path.read_text(encoding="utf-8") == "0"
+
+
+def test_fixture_mode_shutdown_marks_interrupt(tmp_path: Path, monkeypatch) -> None:
+    original_settings = run._settings  # type: ignore[attr-defined]
+    original_root = run.ROOT
+    (tmp_path / "fixtures.py").write_text(
+        "from tenzir_test.fixtures import fixture\n"
+        "@fixture(name='interrupt_shutdown', replace=True)\n"
+        "def interrupt_shutdown():\n"
+        "    yield {'INTERRUPT_SHUTDOWN': '1'}\n",
+        encoding="utf-8",
+    )
+    hooks_dir = tmp_path / "hooks"
+    hooks_dir.mkdir()
+    log_path = tmp_path / "shutdown-interrupted.log"
+    (hooks_dir / "__init__.py").write_text(
+        "from tenzir_test import hooks\n"
+        "@hooks.shutdown\n"
+        "def shutdown(ctx):\n"
+        f"    open({str(log_path)!r}, 'w').write(f'{{ctx.exit_code}}:{{ctx.interrupted}}')\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(run, "_wait_for_fixture_shutdown", lambda: True)
+    run._HOOK_LOAD_CACHE.clear()  # type: ignore[attr-defined]
+
+    try:
+        exit_code = run.run_fixture_mode_cli(
+            root=tmp_path,
+            package_dirs=(),
+            fixtures=("interrupt_shutdown",),
+            debug=False,
+            keep_tmp_dirs=False,
+        )
+    finally:
+        run._HOOK_LOAD_CACHE.clear()  # type: ignore[attr-defined]
+        _restore_runtime(original_settings, original_root)
+
+    assert exit_code == 0
+    assert log_path.read_text(encoding="utf-8") == "0:True"
 
 
 def test_fixture_mode_wraps_startup_hook_failures(tmp_path: Path, monkeypatch) -> None:
@@ -856,6 +976,100 @@ def test_suite_static_skip_finish_hook_keeps_suite_context(tmp_path: Path, monke
 
     assert result.exit_code == 0
     assert log_path.read_text(encoding="utf-8").splitlines() == ["grouped", "grouped"]
+
+
+def test_project_start_can_override_test_binary_environment(tmp_path: Path, monkeypatch) -> None:
+    original_settings = run._settings  # type: ignore[attr-defined]
+    original_root = run.ROOT
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    (tests_dir / "env.sh").write_text("printf '%s\\n' \"$TENZIR_BINARY\"\n", encoding="utf-8")
+    (tests_dir / "env.txt").write_text("/project/bin/tenzir\n", encoding="utf-8")
+    hooks_dir = tmp_path / "hooks"
+    hooks_dir.mkdir()
+    (hooks_dir / "__init__.py").write_text(
+        "from tenzir_test import hooks\n"
+        "@hooks.project_start\n"
+        "def project_start(ctx):\n"
+        "    ctx.env['TENZIR_BINARY'] = '/project/bin/tenzir'\n"
+        "    ctx.env['TENZIR_NODE_BINARY'] = '/project/bin/tenzir-node'\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("TENZIR_BINARY", "/usr/bin/true")
+    monkeypatch.setenv("TENZIR_NODE_BINARY", "/usr/bin/true")
+    monkeypatch.chdir(tmp_path)
+    run._HOOK_LOAD_CACHE.clear()  # type: ignore[attr-defined]
+
+    try:
+        result = run.execute(root=tmp_path, tests=[])
+    finally:
+        run._HOOK_LOAD_CACHE.clear()  # type: ignore[attr-defined]
+        _restore_runtime(original_settings, original_root)
+
+    assert result.exit_code == 0
+
+
+def test_hook_base_exception_is_reported_from_worker(tmp_path: Path, monkeypatch) -> None:
+    original_settings = run._settings  # type: ignore[attr-defined]
+    original_root = run.ROOT
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    (tests_dir / "ok.sh").write_text("true\n", encoding="utf-8")
+    hooks_dir = tmp_path / "hooks"
+    hooks_dir.mkdir()
+    (hooks_dir / "__init__.py").write_text(
+        "from tenzir_test import hooks\n"
+        "@hooks.test_finish\n"
+        "def finish(ctx):\n"
+        "    raise SystemExit(3)\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("TENZIR_BINARY", "/usr/bin/true")
+    monkeypatch.setenv("TENZIR_NODE_BINARY", "/usr/bin/true")
+    monkeypatch.chdir(tmp_path)
+    run._HOOK_LOAD_CACHE.clear()  # type: ignore[attr-defined]
+
+    try:
+        with pytest.raises(run.HarnessError, match="hook test_finish finish failed"):
+            run.execute(root=tmp_path, tests=[])
+    finally:
+        run._HOOK_LOAD_CACHE.clear()  # type: ignore[attr-defined]
+        _restore_runtime(original_settings, original_root)
+
+
+def test_deferred_tmp_dir_cleanup_runs_when_teardown_hook_fails(
+    tmp_path: Path, monkeypatch
+) -> None:
+    original_settings = run._settings  # type: ignore[attr-defined]
+    original_root = run.ROOT
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    (tests_dir / "ok.sh").write_text("true\n", encoding="utf-8")
+    log_path = tmp_path / "tmp-dir.log"
+    hooks_dir = tmp_path / "hooks"
+    hooks_dir.mkdir()
+    (hooks_dir / "__init__.py").write_text(
+        "from tenzir_test import hooks\n"
+        "@hooks.test_finish\n"
+        "def finish(ctx):\n"
+        f"    open({str(log_path)!r}, 'w').write(str(ctx.tmp_dir))\n"
+        "    raise RuntimeError('finish failed')\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("TENZIR_BINARY", "/usr/bin/true")
+    monkeypatch.setenv("TENZIR_NODE_BINARY", "/usr/bin/true")
+    monkeypatch.chdir(tmp_path)
+    run._HOOK_LOAD_CACHE.clear()  # type: ignore[attr-defined]
+
+    try:
+        with pytest.raises(run.HarnessError, match="finish failed"):
+            run.execute(root=tmp_path, tests=[])
+    finally:
+        run._HOOK_LOAD_CACHE.clear()  # type: ignore[attr-defined]
+        _restore_runtime(original_settings, original_root)
+
+    tmp_dir = Path(log_path.read_text(encoding="utf-8"))
+    assert not tmp_dir.exists()
 
 
 def test_project_finish_runs_after_later_project_start_hook_fails(

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -81,3 +81,103 @@ def test_no_hooks_disables_startup_hook(tmp_path: Path, monkeypatch) -> None:
 
     assert result.exit_code == 0
     assert tenzir_binary == ("/usr/bin/true",)
+
+
+def test_purge_balances_project_hooks(tmp_path: Path, monkeypatch) -> None:
+    original_settings = run._settings  # type: ignore[attr-defined]
+    original_root = run.ROOT
+    (tmp_path / "tests").mkdir()
+    hooks_dir = tmp_path / "hooks"
+    hooks_dir.mkdir()
+    log_path = tmp_path / "hook.log"
+    (hooks_dir / "__init__.py").write_text(
+        "from tenzir_test import hooks\n"
+        "@hooks.project_start\n"
+        "def start(ctx):\n"
+        f"    open({str(log_path)!r}, 'a').write('start\\n')\n"
+        "@hooks.project_finish\n"
+        "def finish(ctx):\n"
+        f"    open({str(log_path)!r}, 'a').write('finish\\n')\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    run._HOOK_LOAD_CACHE.clear()  # type: ignore[attr-defined]
+
+    try:
+        result = run.execute(root=tmp_path, tests=[], purge=True)
+    finally:
+        run._HOOK_LOAD_CACHE.clear()  # type: ignore[attr-defined]
+        _restore_runtime(original_settings, original_root)
+
+    assert result.exit_code == 0
+    assert log_path.read_text(encoding="utf-8").splitlines() == ["start", "finish"]
+
+
+def test_fixture_mode_invokes_shutdown_hooks(tmp_path: Path, monkeypatch) -> None:
+    original_settings = run._settings  # type: ignore[attr-defined]
+    original_root = run.ROOT
+    (tmp_path / "fixtures.py").write_text(
+        "from tenzir_test.fixtures import fixture\n"
+        "@fixture(name='demo_shutdown', replace=True)\n"
+        "def demo_shutdown():\n"
+        "    yield {'DEMO_SHUTDOWN': '1'}\n",
+        encoding="utf-8",
+    )
+    hooks_dir = tmp_path / "hooks"
+    hooks_dir.mkdir()
+    log_path = tmp_path / "shutdown.log"
+    (hooks_dir / "__init__.py").write_text(
+        "from tenzir_test import hooks\n"
+        "@hooks.shutdown\n"
+        "def shutdown(ctx):\n"
+        f"    open({str(log_path)!r}, 'w').write(str(ctx.exit_code))\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(run, "_wait_for_fixture_shutdown", lambda: None)
+    run._HOOK_LOAD_CACHE.clear()  # type: ignore[attr-defined]
+
+    try:
+        exit_code = run.run_fixture_mode_cli(
+            root=tmp_path,
+            package_dirs=(),
+            fixtures=("demo_shutdown",),
+            debug=False,
+            keep_tmp_dirs=False,
+        )
+    finally:
+        run._HOOK_LOAD_CACHE.clear()  # type: ignore[attr-defined]
+        _restore_runtime(original_settings, original_root)
+
+    assert exit_code == 0
+    assert log_path.read_text(encoding="utf-8") == "0"
+
+
+def test_fixture_mode_wraps_startup_hook_failures(tmp_path: Path, monkeypatch) -> None:
+    import pytest
+
+    original_settings = run._settings  # type: ignore[attr-defined]
+    original_root = run.ROOT
+    hooks_dir = tmp_path / "hooks"
+    hooks_dir.mkdir()
+    (hooks_dir / "__init__.py").write_text(
+        "from tenzir_test import hooks\n"
+        "@hooks.startup\n"
+        "def explode(ctx):\n"
+        "    raise RuntimeError('boom')\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(run, "_wait_for_fixture_shutdown", lambda: None)
+    run._HOOK_LOAD_CACHE.clear()  # type: ignore[attr-defined]
+
+    try:
+        with pytest.raises(run.HarnessError, match="hook startup explode failed"):
+            run.run_fixture_mode_cli(
+                root=tmp_path,
+                package_dirs=(),
+                fixtures=("missing",),
+                debug=False,
+                keep_tmp_dirs=False,
+            )
+    finally:
+        run._HOOK_LOAD_CACHE.clear()  # type: ignore[attr-defined]
+        _restore_runtime(original_settings, original_root)

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -653,3 +653,152 @@ def test_fixture_mode_shutdown_hook_failure_is_not_retried(tmp_path: Path, monke
         _restore_runtime(original_settings, original_root)
 
     assert log_path.read_text(encoding="utf-8").splitlines() == ["shutdown:0"]
+
+
+def test_fixture_mode_invokes_shutdown_after_settings_failure(tmp_path: Path, monkeypatch) -> None:
+    original_settings = run._settings  # type: ignore[attr-defined]
+    original_root = run.ROOT
+    original_env = dict(os.environ)
+    hooks_dir = tmp_path / "hooks"
+    hooks_dir.mkdir()
+    log_path = tmp_path / "settings-shutdown.log"
+    (hooks_dir / "__init__.py").write_text(
+        "from tenzir_test import hooks\n"
+        "@hooks.startup\n"
+        "def startup(ctx):\n"
+        "    ctx.env['TENZIR_BINARY'] = '\"unterminated'\n"
+        "@hooks.shutdown\n"
+        "def shutdown(ctx):\n"
+        f"    open({str(log_path)!r}, 'w').write(str(ctx.exit_code))\n",
+        encoding="utf-8",
+    )
+    run._HOOK_LOAD_CACHE.clear()  # type: ignore[attr-defined]
+
+    try:
+        with pytest.raises(ValueError, match="Invalid shell syntax"):
+            run.run_fixture_mode_cli(
+                root=tmp_path,
+                package_dirs=(),
+                fixtures=("missing",),
+                debug=False,
+                keep_tmp_dirs=False,
+            )
+    finally:
+        run._HOOK_LOAD_CACHE.clear()  # type: ignore[attr-defined]
+        os.environ.clear()
+        os.environ.update(original_env)
+        _restore_runtime(original_settings, original_root)
+
+    assert log_path.read_text(encoding="utf-8") == "1"
+
+
+def test_cleared_hook_path_removes_path_from_environment(tmp_path: Path, monkeypatch) -> None:
+    original_settings = run._settings  # type: ignore[attr-defined]
+    original_root = run.ROOT
+    original_env = dict(os.environ)
+    (tmp_path / "tests").mkdir()
+    hooks_dir = tmp_path / "hooks"
+    hooks_dir.mkdir()
+    (hooks_dir / "__init__.py").write_text(
+        "from tenzir_test import hooks\n@hooks.startup\ndef startup(ctx):\n    ctx.path.clear()\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("PATH", "/usr/bin")
+    monkeypatch.chdir(tmp_path)
+    run._HOOK_LOAD_CACHE.clear()  # type: ignore[attr-defined]
+
+    try:
+        result = run.execute(root=tmp_path, tests=[])
+        path_present = "PATH" in os.environ
+    finally:
+        run._HOOK_LOAD_CACHE.clear()  # type: ignore[attr-defined]
+        os.environ.clear()
+        os.environ.update(original_env)
+        _restore_runtime(original_settings, original_root)
+
+    assert result.exit_code == 0
+    assert not path_present
+
+
+def test_suite_static_skip_finish_hook_keeps_suite_context(tmp_path: Path, monkeypatch) -> None:
+    original_settings = run._settings  # type: ignore[attr-defined]
+    original_root = run.ROOT
+    log_path = tmp_path / "suite-context.log"
+    hooks_dir = tmp_path / "hooks"
+    hooks_dir.mkdir()
+    (hooks_dir / "__init__.py").write_text(
+        "from tenzir_test import hooks\n"
+        "@hooks.test_finish\n"
+        "def finish(ctx):\n"
+        f"    open({str(log_path)!r}, 'a').write(str(ctx.suite.name if ctx.suite else None) + '\\n')\n",
+        encoding="utf-8",
+    )
+    suite_dir = tmp_path / "tests" / "suite"
+    suite_dir.mkdir(parents=True)
+    (suite_dir / "test.yaml").write_text("suite: grouped\n", encoding="utf-8")
+    for name in ("one.tql", "two.tql"):
+        (suite_dir / name).write_text("---\nskip: static\n---\nversion\n", encoding="utf-8")
+    monkeypatch.setenv("TENZIR_BINARY", "/usr/bin/true")
+    monkeypatch.setenv("TENZIR_NODE_BINARY", "/usr/bin/true")
+    monkeypatch.chdir(tmp_path)
+    run._HOOK_LOAD_CACHE.clear()  # type: ignore[attr-defined]
+
+    try:
+        result = run.execute(root=tmp_path, tests=[])
+    finally:
+        run._HOOK_LOAD_CACHE.clear()  # type: ignore[attr-defined]
+        _restore_runtime(original_settings, original_root)
+
+    assert result.exit_code == 0
+    assert log_path.read_text(encoding="utf-8").splitlines() == ["grouped", "grouped"]
+
+
+def test_project_finish_runs_after_later_project_start_hook_fails(
+    tmp_path: Path, monkeypatch
+) -> None:
+    original_settings = run._settings  # type: ignore[attr-defined]
+    original_root = run.ROOT
+    root = tmp_path / "root"
+    (root / "tests").mkdir(parents=True)
+    log_path = root / "partial-project.log"
+    hooks_dir = root / "hooks"
+    hooks_dir.mkdir()
+    (hooks_dir / "__init__.py").write_text(
+        "from tenzir_test import hooks\n"
+        "@hooks.project_start\n"
+        "def start(ctx):\n"
+        f"    open({str(log_path)!r}, 'a').write('root-start\\n')\n"
+        "@hooks.project_finish\n"
+        "def finish(ctx):\n"
+        f"    open({str(log_path)!r}, 'a').write('root-finish\\n')\n",
+        encoding="utf-8",
+    )
+    satellite = root / "satellite"
+    (satellite / "tests").mkdir(parents=True)
+    satellite_hooks = satellite / "hooks"
+    satellite_hooks.mkdir()
+    (satellite_hooks / "__init__.py").write_text(
+        "from tenzir_test import hooks\n"
+        "@hooks.project_start\n"
+        "def fail(ctx):\n"
+        "    raise RuntimeError('satellite start failed')\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("TENZIR_BINARY", "/usr/bin/true")
+    monkeypatch.setenv("TENZIR_NODE_BINARY", "/usr/bin/true")
+    monkeypatch.chdir(root)
+    run._HOOK_LOAD_CACHE.clear()  # type: ignore[attr-defined]
+
+    try:
+        with pytest.raises(run.HarnessError, match="satellite start failed"):
+            run.execute(root=root, tests=[Path("satellite")], all_projects=True)
+    finally:
+        run._HOOK_LOAD_CACHE.clear()  # type: ignore[attr-defined]
+        _restore_runtime(original_settings, original_root)
+
+    assert log_path.read_text(encoding="utf-8").splitlines() == [
+        "root-start",
+        "root-finish",
+        "root-start",
+        "root-finish",
+    ]

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -779,6 +779,52 @@ def test_interrupted_test_before_first_attempt_balances_test_hooks(
     ]
 
 
+def test_worker_hook_failure_preserves_partial_summary_for_teardown(
+    tmp_path: Path, monkeypatch
+) -> None:
+    original_settings = run._settings  # type: ignore[attr-defined]
+    original_root = run.ROOT
+    original_env = dict(os.environ)
+    log_path = tmp_path / "partial-summary.log"
+    hooks_dir = tmp_path / "hooks"
+    hooks_dir.mkdir()
+    (hooks_dir / "__init__.py").write_text(
+        "from tenzir_test import hooks\n"
+        "@hooks.test_finish\n"
+        "def fail_finish(ctx):\n"
+        "    raise RuntimeError('finish boom')\n"
+        "@hooks.project_finish\n"
+        "def project_finish(ctx):\n"
+        f"    open({str(log_path)!r}, 'a').write('project:' + str(ctx.summary.total) + '\\n')\n"
+        "@hooks.shutdown\n"
+        "def shutdown(ctx):\n"
+        f"    open({str(log_path)!r}, 'a').write('shutdown:' + str(ctx.summary.total) + '\\n')\n",
+        encoding="utf-8",
+    )
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    (tests_dir / "ok.sh").write_text("true\n", encoding="utf-8")
+    (tests_dir / "ok.txt").write_text("", encoding="utf-8")
+    monkeypatch.setenv("TENZIR_BINARY", "/usr/bin/true")
+    monkeypatch.setenv("TENZIR_NODE_BINARY", "/usr/bin/true")
+    monkeypatch.chdir(tmp_path)
+    run._HOOK_LOAD_CACHE.clear()  # type: ignore[attr-defined]
+
+    try:
+        with pytest.raises(run.HarnessError, match="finish boom"):
+            run.execute(root=tmp_path, tests=[], jobs=1)
+    finally:
+        run._HOOK_LOAD_CACHE.clear()  # type: ignore[attr-defined]
+        os.environ.clear()
+        os.environ.update(original_env)
+        _restore_runtime(original_settings, original_root)
+
+    assert log_path.read_text(encoding="utf-8").splitlines() == [
+        "project:1",
+        "shutdown:1",
+    ]
+
+
 def test_suite_static_skip_finish_hook_keeps_suite_context(tmp_path: Path, monkeypatch) -> None:
     original_settings = run._settings  # type: ignore[attr-defined]
     original_root = run.ROOT

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from tenzir_test import run
+
+
+def _restore_runtime(original_settings: object, original_root: Path) -> None:
+    if original_settings is not None:
+        run.apply_settings(original_settings)  # type: ignore[arg-type]
+    else:
+        run._settings = None  # type: ignore[attr-defined]
+        run.TENZIR_BINARY = None
+        run.TENZIR_NODE_BINARY = None
+        run._set_project_root(original_root)  # type: ignore[attr-defined]
+
+
+def test_startup_hook_can_set_binary_before_settings_discovery(tmp_path: Path, monkeypatch) -> None:
+    original_settings = run._settings  # type: ignore[attr-defined]
+    original_root = run.ROOT
+    original_env = dict(os.environ)
+    (tmp_path / "tests").mkdir()
+    hooks_dir = tmp_path / "hooks"
+    hooks_dir.mkdir()
+    (hooks_dir / "__init__.py").write_text(
+        "from tenzir_test import hooks\n"
+        "@hooks.startup\n"
+        "def configure(ctx):\n"
+        "    ctx.env['TENZIR_BINARY'] = '/usr/bin/true'\n"
+        "    ctx.env['TENZIR_NODE_BINARY'] = '/usr/bin/true'\n",
+        encoding="utf-8",
+    )
+    monkeypatch.delenv("TENZIR_BINARY", raising=False)
+    monkeypatch.delenv("TENZIR_NODE_BINARY", raising=False)
+    monkeypatch.chdir(tmp_path)
+    run._HOOK_LOAD_CACHE.clear()  # type: ignore[attr-defined]
+
+    try:
+        result = run.execute(root=tmp_path, tests=[])
+        tenzir_binary = run.TENZIR_BINARY
+        tenzir_node_binary = run.TENZIR_NODE_BINARY
+    finally:
+        run._HOOK_LOAD_CACHE.clear()  # type: ignore[attr-defined]
+        os.environ.clear()
+        os.environ.update(original_env)
+        _restore_runtime(original_settings, original_root)
+
+    assert result.exit_code == 0
+    assert tenzir_binary == ("/usr/bin/true",)
+    assert tenzir_node_binary == ("/usr/bin/true",)
+
+
+def test_no_hooks_disables_startup_hook(tmp_path: Path, monkeypatch) -> None:
+    original_settings = run._settings  # type: ignore[attr-defined]
+    original_root = run.ROOT
+    original_env = dict(os.environ)
+    (tmp_path / "tests").mkdir()
+    hooks_dir = tmp_path / "hooks"
+    hooks_dir.mkdir()
+    (hooks_dir / "__init__.py").write_text(
+        "from tenzir_test import hooks\n"
+        "@hooks.startup\n"
+        "def configure(ctx):\n"
+        "    ctx.env['TENZIR_BINARY'] = '/definitely/not/used'\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("TENZIR_BINARY", "/usr/bin/true")
+    monkeypatch.setenv("TENZIR_NODE_BINARY", "/usr/bin/true")
+    monkeypatch.chdir(tmp_path)
+    run._HOOK_LOAD_CACHE.clear()  # type: ignore[attr-defined]
+
+    try:
+        result = run.execute(root=tmp_path, tests=[], no_hooks=True)
+        tenzir_binary = run.TENZIR_BINARY
+    finally:
+        run._HOOK_LOAD_CACHE.clear()  # type: ignore[attr-defined]
+        os.environ.clear()
+        os.environ.update(original_env)
+        _restore_runtime(original_settings, original_root)
+
+    assert result.exit_code == 0
+    assert tenzir_binary == ("/usr/bin/true",)

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -720,6 +720,53 @@ def test_cleared_hook_path_removes_path_from_environment(tmp_path: Path, monkeyp
     assert not path_present
 
 
+def test_interrupted_test_before_first_attempt_balances_test_hooks(
+    tmp_path: Path, monkeypatch
+) -> None:
+    original_settings = run._settings  # type: ignore[attr-defined]
+    original_root = run.ROOT
+    log_path = tmp_path / "interrupted-test-hooks.log"
+    hooks_dir = tmp_path / "hooks"
+    hooks_dir.mkdir()
+    (hooks_dir / "__init__.py").write_text(
+        "from tenzir_test import hooks, run\n"
+        "@hooks.test_start\n"
+        "def start(ctx):\n"
+        f"    open({str(log_path)!r}, 'a').write('start:' + str(ctx.attempt_limit) + '\\n')\n"
+        "    run._request_interrupt()\n"
+        "@hooks.test_finish\n"
+        "def finish(ctx):\n"
+        f"    open({str(log_path)!r}, 'a').write('finish:' + ctx.outcome + ':' + str(ctx.attempts) + '\\n')\n"
+        "@hooks.test_failure\n"
+        "def failure(ctx):\n"
+        f"    open({str(log_path)!r}, 'a').write('failure:' + str(ctx.attempts) + '\\n')\n",
+        encoding="utf-8",
+    )
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    (tests_dir / "interrupted.tql").write_text("version\n", encoding="utf-8")
+    monkeypatch.setenv("TENZIR_BINARY", "/usr/bin/true")
+    monkeypatch.setenv("TENZIR_NODE_BINARY", "/usr/bin/true")
+    monkeypatch.chdir(tmp_path)
+    run._HOOK_LOAD_CACHE.clear()  # type: ignore[attr-defined]
+
+    try:
+        result = run.execute(root=tmp_path, tests=[])
+    finally:
+        run._HOOK_LOAD_CACHE.clear()  # type: ignore[attr-defined]
+        run._INTERRUPT_EVENT.clear()  # type: ignore[attr-defined]
+        run._INTERRUPT_ANNOUNCED.clear()  # type: ignore[attr-defined]
+        _restore_runtime(original_settings, original_root)
+
+    assert result.exit_code == 130
+    assert result.interrupted
+    assert log_path.read_text(encoding="utf-8").splitlines() == [
+        "start:1",
+        "finish:failed:0",
+        "failure:0",
+    ]
+
+
 def test_suite_static_skip_finish_hook_keeps_suite_context(tmp_path: Path, monkeypatch) -> None:
     original_settings = run._settings  # type: ignore[attr-defined]
     original_root = run.ROOT

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -361,3 +361,66 @@ def test_project_env_keeps_diagnostics_flag(tmp_path: Path, monkeypatch) -> None
         _restore_runtime(original_settings, original_root)
 
     assert result.exit_code == 0
+
+
+def test_project_env_can_be_intentionally_empty(tmp_path: Path) -> None:
+    original_project_env = run._CURRENT_PROJECT_ENV  # type: ignore[attr-defined]
+    original_root = run.ROOT
+    test_path = tmp_path / "tests" / "sample.tql"
+    test_path.parent.mkdir(parents=True)
+    test_path.write_text("version\n", encoding="utf-8")
+
+    try:
+        run._set_project_root(tmp_path)  # type: ignore[attr-defined]
+        run._CURRENT_PROJECT_ENV = {}  # type: ignore[attr-defined]
+        env, _config_args = run.get_test_env_and_config_args(test_path)
+    finally:
+        run.cleanup_test_tmp_dir(env.get(run.TEST_TMP_ENV_VAR) if "env" in locals() else None)
+        run._CURRENT_PROJECT_ENV = original_project_env  # type: ignore[attr-defined]
+        run._set_project_root(original_root)  # type: ignore[attr-defined]
+
+    assert "PATH" not in env
+    assert "HOME" not in env
+    assert env["TENZIR_TEST_ROOT"] == str(tmp_path)
+
+
+def test_fixture_mode_invokes_shutdown_hooks_after_runtime_failure(
+    tmp_path: Path, monkeypatch
+) -> None:
+    original_settings = run._settings  # type: ignore[attr-defined]
+    original_root = run.ROOT
+    (tmp_path / "fixtures.py").write_text(
+        "from tenzir_test.fixtures import fixture\n"
+        "@fixture(name='demo_failure', replace=True)\n"
+        "def demo_failure():\n"
+        "    raise RuntimeError('fixture exploded')\n"
+        "    yield {}\n",
+        encoding="utf-8",
+    )
+    hooks_dir = tmp_path / "hooks"
+    hooks_dir.mkdir()
+    log_path = tmp_path / "shutdown.log"
+    (hooks_dir / "__init__.py").write_text(
+        "from tenzir_test import hooks\n"
+        "@hooks.shutdown\n"
+        "def shutdown(ctx):\n"
+        f"    open({str(log_path)!r}, 'w').write(str(ctx.exit_code))\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(run, "_wait_for_fixture_shutdown", lambda: None)
+    run._HOOK_LOAD_CACHE.clear()  # type: ignore[attr-defined]
+
+    try:
+        with pytest.raises(RuntimeError, match="fixture exploded"):
+            run.run_fixture_mode_cli(
+                root=tmp_path,
+                package_dirs=(),
+                fixtures=("demo_failure",),
+                debug=False,
+                keep_tmp_dirs=False,
+            )
+    finally:
+        run._HOOK_LOAD_CACHE.clear()  # type: ignore[attr-defined]
+        _restore_runtime(original_settings, original_root)
+
+    assert log_path.read_text(encoding="utf-8") == "1"

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 
-from tenzir_test import run
+from tenzir_test import hooks, run
 
 
 def _restore_runtime(original_settings: object, original_root: Path) -> None:
@@ -334,6 +334,18 @@ def test_project_finish_and_shutdown_run_after_project_setup_failure(
         "finish",
         "shutdown:1",
     ]
+
+
+def test_hook_environment_clear_removes_path() -> None:
+    env = {"PATH": "/bin", "HOME": "/home/test"}
+    path = ["/usr/bin"]
+    hook_env = hooks.HookEnvironment(env, path)
+
+    hook_env.clear()
+
+    assert env == {}
+    assert path == []
+    assert list(hook_env) == []
 
 
 def test_project_env_keeps_diagnostics_flag(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -53,6 +53,70 @@ def test_startup_hook_can_set_binary_before_settings_discovery(tmp_path: Path, m
     assert tenzir_node_binary == ("/usr/bin/true",)
 
 
+def test_startup_hook_path_updates_binary_discovery(tmp_path: Path, monkeypatch) -> None:
+    original_settings = run._settings  # type: ignore[attr-defined]
+    original_root = run.ROOT
+    original_env = dict(os.environ)
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    (bin_dir / "tenzir").write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    (bin_dir / "tenzir-node").write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    (bin_dir / "tenzir").chmod(0o755)
+    (bin_dir / "tenzir-node").chmod(0o755)
+    (tmp_path / "tests").mkdir()
+    hooks_dir = tmp_path / "hooks"
+    hooks_dir.mkdir()
+    (hooks_dir / "__init__.py").write_text(
+        "from tenzir_test import hooks\n"
+        "@hooks.startup\n"
+        "def configure(ctx):\n"
+        f"    ctx.path.insert(0, {str(bin_dir)!r})\n",
+        encoding="utf-8",
+    )
+    monkeypatch.delenv("TENZIR_BINARY", raising=False)
+    monkeypatch.delenv("TENZIR_NODE_BINARY", raising=False)
+    monkeypatch.setenv("PATH", "/usr/bin")
+    monkeypatch.chdir(tmp_path)
+    run._HOOK_LOAD_CACHE.clear()  # type: ignore[attr-defined]
+
+    try:
+        result = run.execute(root=tmp_path, tests=[])
+        tenzir_binary = run.TENZIR_BINARY
+        tenzir_node_binary = run.TENZIR_NODE_BINARY
+    finally:
+        run._HOOK_LOAD_CACHE.clear()  # type: ignore[attr-defined]
+        os.environ.clear()
+        os.environ.update(original_env)
+        _restore_runtime(original_settings, original_root)
+
+    assert result.exit_code == 0
+    assert tenzir_binary == (str(bin_dir / "tenzir"),)
+    assert tenzir_node_binary == (str(bin_dir / "tenzir-node"),)
+
+
+def test_startup_hook_rejects_env_path_mutation(tmp_path: Path, monkeypatch) -> None:
+    original_settings = run._settings  # type: ignore[attr-defined]
+    original_root = run.ROOT
+    (tmp_path / "tests").mkdir()
+    hooks_dir = tmp_path / "hooks"
+    hooks_dir.mkdir()
+    (hooks_dir / "__init__.py").write_text(
+        "from tenzir_test import hooks\n"
+        "@hooks.startup\n"
+        "def configure(ctx):\n"
+        "    ctx.env['PATH'] = '/tmp/bin'\n",
+        encoding="utf-8",
+    )
+    run._HOOK_LOAD_CACHE.clear()  # type: ignore[attr-defined]
+
+    try:
+        with pytest.raises(run.HarnessError, match="modify ctx.path"):
+            run.execute(root=tmp_path, tests=[])
+    finally:
+        run._HOOK_LOAD_CACHE.clear()  # type: ignore[attr-defined]
+        _restore_runtime(original_settings, original_root)
+
+
 def test_no_hooks_disables_startup_hook(tmp_path: Path, monkeypatch) -> None:
     original_settings = run._settings  # type: ignore[attr-defined]
     original_root = run.ROOT

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -424,3 +424,89 @@ def test_fixture_mode_invokes_shutdown_hooks_after_runtime_failure(
         _restore_runtime(original_settings, original_root)
 
     assert log_path.read_text(encoding="utf-8") == "1"
+
+
+def test_satellite_test_hooks_keep_invocation_root(tmp_path: Path, monkeypatch) -> None:
+    original_settings = run._settings  # type: ignore[attr-defined]
+    original_root = run.ROOT
+    root = tmp_path / "root"
+    root.mkdir()
+    (root / "tests").mkdir()
+    hooks_dir = root / "hooks"
+    hooks_dir.mkdir()
+    log_path = root / "hook-root.log"
+    (hooks_dir / "__init__.py").write_text(
+        "from tenzir_test import hooks\n"
+        "@hooks.test_finish\n"
+        "def finish(ctx):\n"
+        f"    open({str(log_path)!r}, 'w').write(str(ctx.root))\n",
+        encoding="utf-8",
+    )
+    satellite = root / "satellite"
+    tests_dir = satellite / "tests"
+    tests_dir.mkdir(parents=True)
+    (tests_dir / "skip.tql").write_text(
+        "---\nskip: static\n---\nversion\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("TENZIR_BINARY", "/usr/bin/true")
+    monkeypatch.setenv("TENZIR_NODE_BINARY", "/usr/bin/true")
+    monkeypatch.chdir(root)
+    run._HOOK_LOAD_CACHE.clear()  # type: ignore[attr-defined]
+
+    try:
+        result = run.execute(root=root, tests=[Path("satellite")])
+    finally:
+        run._HOOK_LOAD_CACHE.clear()  # type: ignore[attr-defined]
+        _restore_runtime(original_settings, original_root)
+
+    assert result.exit_code == 0
+    assert log_path.read_text(encoding="utf-8") == str(root.resolve())
+
+
+def test_shutdown_after_late_failure_receives_accumulated_summary(
+    tmp_path: Path, monkeypatch
+) -> None:
+    original_settings = run._settings  # type: ignore[attr-defined]
+    original_root = run.ROOT
+    root = tmp_path / "root"
+    tests_dir = root / "tests"
+    tests_dir.mkdir(parents=True)
+    (tests_dir / "skip.tql").write_text(
+        "---\nskip: static\n---\nversion\n",
+        encoding="utf-8",
+    )
+    log_path = root / "shutdown-summary.log"
+    hooks_dir = root / "hooks"
+    hooks_dir.mkdir()
+    (hooks_dir / "__init__.py").write_text(
+        "from tenzir_test import hooks\n"
+        "@hooks.shutdown\n"
+        "def shutdown(ctx):\n"
+        f"    open({str(log_path)!r}, 'w').write(str(ctx.summary.total))\n",
+        encoding="utf-8",
+    )
+    satellite = root / "satellite"
+    (satellite / "tests").mkdir(parents=True)
+    satellite_hooks = satellite / "hooks"
+    satellite_hooks.mkdir()
+    (satellite_hooks / "__init__.py").write_text(
+        "from tenzir_test import hooks\n"
+        "@hooks.project_start\n"
+        "def fail(ctx):\n"
+        "    raise RuntimeError('late failure')\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("TENZIR_BINARY", "/usr/bin/true")
+    monkeypatch.setenv("TENZIR_NODE_BINARY", "/usr/bin/true")
+    monkeypatch.chdir(root)
+    run._HOOK_LOAD_CACHE.clear()  # type: ignore[attr-defined]
+
+    try:
+        with pytest.raises(run.HarnessError, match="late failure"):
+            run.execute(root=root, tests=[Path("satellite")], all_projects=True)
+    finally:
+        run._HOOK_LOAD_CACHE.clear()  # type: ignore[attr-defined]
+        _restore_runtime(original_settings, original_root)
+
+    assert log_path.read_text(encoding="utf-8") == "1"

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -544,3 +544,112 @@ def test_fixture_mode_invokes_shutdown_hooks_after_pre_activation_failure(
         _restore_runtime(original_settings, original_root)
 
     assert log_path.read_text(encoding="utf-8") == "1"
+
+
+def test_project_finish_hook_failure_is_not_retried(tmp_path: Path, monkeypatch) -> None:
+    original_settings = run._settings  # type: ignore[attr-defined]
+    original_root = run.ROOT
+    original_env = dict(os.environ)
+    (tmp_path / "tests").mkdir()
+    hooks_dir = tmp_path / "hooks"
+    hooks_dir.mkdir()
+    log_path = tmp_path / "project-finish.log"
+    (hooks_dir / "__init__.py").write_text(
+        "from tenzir_test import hooks\n"
+        "@hooks.project_start\n"
+        "def start(ctx):\n"
+        "    pass\n"
+        "@hooks.project_finish\n"
+        "def finish(ctx):\n"
+        f"    open({str(log_path)!r}, 'a').write('finish\\n')\n"
+        "    raise RuntimeError('finish failed')\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("TENZIR_BINARY", "/usr/bin/true")
+    monkeypatch.setenv("TENZIR_NODE_BINARY", "/usr/bin/true")
+    monkeypatch.chdir(tmp_path)
+    run._HOOK_LOAD_CACHE.clear()  # type: ignore[attr-defined]
+
+    try:
+        with pytest.raises(run.HarnessError, match="hook project_finish finish failed"):
+            run.execute(root=tmp_path, tests=[], purge=True)
+    finally:
+        run._HOOK_LOAD_CACHE.clear()  # type: ignore[attr-defined]
+        os.environ.clear()
+        os.environ.update(original_env)
+        _restore_runtime(original_settings, original_root)
+
+    assert log_path.read_text(encoding="utf-8").splitlines() == ["finish"]
+
+
+def test_shutdown_hook_failure_is_not_retried(tmp_path: Path, monkeypatch) -> None:
+    original_settings = run._settings  # type: ignore[attr-defined]
+    original_root = run.ROOT
+    original_env = dict(os.environ)
+    (tmp_path / "tests").mkdir()
+    hooks_dir = tmp_path / "hooks"
+    hooks_dir.mkdir()
+    log_path = tmp_path / "shutdown.log"
+    (hooks_dir / "__init__.py").write_text(
+        "from tenzir_test import hooks\n"
+        "@hooks.shutdown\n"
+        "def shutdown(ctx):\n"
+        f"    open({str(log_path)!r}, 'a').write('shutdown:' + str(ctx.exit_code) + '\\n')\n"
+        "    raise RuntimeError('shutdown failed')\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("TENZIR_BINARY", "/usr/bin/true")
+    monkeypatch.setenv("TENZIR_NODE_BINARY", "/usr/bin/true")
+    monkeypatch.chdir(tmp_path)
+    run._HOOK_LOAD_CACHE.clear()  # type: ignore[attr-defined]
+
+    try:
+        with pytest.raises(run.HarnessError, match="hook shutdown shutdown failed"):
+            run.execute(root=tmp_path, tests=[])
+    finally:
+        run._HOOK_LOAD_CACHE.clear()  # type: ignore[attr-defined]
+        os.environ.clear()
+        os.environ.update(original_env)
+        _restore_runtime(original_settings, original_root)
+
+    assert log_path.read_text(encoding="utf-8").splitlines() == ["shutdown:0"]
+
+
+def test_fixture_mode_shutdown_hook_failure_is_not_retried(tmp_path: Path, monkeypatch) -> None:
+    original_settings = run._settings  # type: ignore[attr-defined]
+    original_root = run.ROOT
+    (tmp_path / "fixtures.py").write_text(
+        "from tenzir_test.fixtures import fixture\n"
+        "@fixture(name='demo_shutdown_failure', replace=True)\n"
+        "def demo_shutdown_failure():\n"
+        "    yield {'DEMO_SHUTDOWN_FAILURE': '1'}\n",
+        encoding="utf-8",
+    )
+    hooks_dir = tmp_path / "hooks"
+    hooks_dir.mkdir()
+    log_path = tmp_path / "fixture-shutdown.log"
+    (hooks_dir / "__init__.py").write_text(
+        "from tenzir_test import hooks\n"
+        "@hooks.shutdown\n"
+        "def shutdown(ctx):\n"
+        f"    open({str(log_path)!r}, 'a').write('shutdown:' + str(ctx.exit_code) + '\\n')\n"
+        "    raise RuntimeError('shutdown failed')\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(run, "_wait_for_fixture_shutdown", lambda: None)
+    run._HOOK_LOAD_CACHE.clear()  # type: ignore[attr-defined]
+
+    try:
+        with pytest.raises(run.HarnessError, match="hook shutdown shutdown failed"):
+            run.run_fixture_mode_cli(
+                root=tmp_path,
+                package_dirs=(),
+                fixtures=("demo_shutdown_failure",),
+                debug=False,
+                keep_tmp_dirs=False,
+            )
+    finally:
+        run._HOOK_LOAD_CACHE.clear()  # type: ignore[attr-defined]
+        _restore_runtime(original_settings, original_root)
+
+    assert log_path.read_text(encoding="utf-8").splitlines() == ["shutdown:0"]

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
+import pytest
+
 from tenzir_test import run
 
 
@@ -153,8 +155,6 @@ def test_fixture_mode_invokes_shutdown_hooks(tmp_path: Path, monkeypatch) -> Non
 
 
 def test_fixture_mode_wraps_startup_hook_failures(tmp_path: Path, monkeypatch) -> None:
-    import pytest
-
     original_settings = run._settings  # type: ignore[attr-defined]
     original_root = run.ROOT
     hooks_dir = tmp_path / "hooks"
@@ -181,3 +181,119 @@ def test_fixture_mode_wraps_startup_hook_failures(tmp_path: Path, monkeypatch) -
     finally:
         run._HOOK_LOAD_CACHE.clear()  # type: ignore[attr-defined]
         _restore_runtime(original_settings, original_root)
+
+
+def test_fixture_mode_invokes_shutdown_after_fixture_unavailable(
+    tmp_path: Path, monkeypatch
+) -> None:
+    original_settings = run._settings  # type: ignore[attr-defined]
+    original_root = run.ROOT
+    (tmp_path / "fixtures.py").write_text(
+        "from tenzir_test.fixtures import FixtureUnavailable, fixture\n"
+        "@fixture(name='unavailable_shutdown', replace=True)\n"
+        "def unavailable_shutdown():\n"
+        "    raise FixtureUnavailable('not ready')\n"
+        "    yield {}\n",
+        encoding="utf-8",
+    )
+    hooks_dir = tmp_path / "hooks"
+    hooks_dir.mkdir()
+    log_path = tmp_path / "shutdown.log"
+    (hooks_dir / "__init__.py").write_text(
+        "from tenzir_test import hooks\n"
+        "@hooks.shutdown\n"
+        "def shutdown(ctx):\n"
+        f"    open({str(log_path)!r}, 'w').write(str(ctx.exit_code))\n",
+        encoding="utf-8",
+    )
+    run._HOOK_LOAD_CACHE.clear()  # type: ignore[attr-defined]
+
+    try:
+        with pytest.raises(run.HarnessError, match="fixture unavailable: not ready"):
+            run.run_fixture_mode_cli(
+                root=tmp_path,
+                package_dirs=(),
+                fixtures=("unavailable_shutdown",),
+                debug=False,
+                keep_tmp_dirs=False,
+            )
+    finally:
+        run._HOOK_LOAD_CACHE.clear()  # type: ignore[attr-defined]
+        _restore_runtime(original_settings, original_root)
+
+    assert log_path.read_text(encoding="utf-8") == "1"
+
+
+def test_project_finish_and_shutdown_run_after_project_setup_failure(
+    tmp_path: Path, monkeypatch
+) -> None:
+    original_settings = run._settings  # type: ignore[attr-defined]
+    original_root = run.ROOT
+    original_env = dict(os.environ)
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    (tests_dir / "broken.tql").write_text("version\n", encoding="utf-8")
+    hooks_dir = tmp_path / "hooks"
+    hooks_dir.mkdir()
+    log_path = tmp_path / "hook.log"
+    (hooks_dir / "__init__.py").write_text(
+        "from tenzir_test import hooks\n"
+        "@hooks.startup\n"
+        "def startup(ctx):\n"
+        "    ctx.env['TENZIR_BINARY'] = '/definitely/missing/tenzir'\n"
+        "    ctx.env['TENZIR_NODE_BINARY'] = '/usr/bin/true'\n"
+        "@hooks.project_start\n"
+        "def start(ctx):\n"
+        f"    open({str(log_path)!r}, 'a').write('start\\n')\n"
+        "@hooks.project_finish\n"
+        "def finish(ctx):\n"
+        f"    open({str(log_path)!r}, 'a').write('finish\\n')\n"
+        "@hooks.shutdown\n"
+        "def shutdown(ctx):\n"
+        f"    open({str(log_path)!r}, 'a').write('shutdown:' + str(ctx.exit_code) + '\\n')\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    run._HOOK_LOAD_CACHE.clear()  # type: ignore[attr-defined]
+
+    try:
+        with pytest.raises(run.HarnessError):
+            run.execute(root=tmp_path, tests=[])
+    finally:
+        run._HOOK_LOAD_CACHE.clear()  # type: ignore[attr-defined]
+        os.environ.clear()
+        os.environ.update(original_env)
+        _restore_runtime(original_settings, original_root)
+
+    assert log_path.read_text(encoding="utf-8").splitlines() == [
+        "start",
+        "finish",
+        "shutdown:1",
+    ]
+
+
+def test_project_env_keeps_diagnostics_flag(tmp_path: Path, monkeypatch) -> None:
+    original_settings = run._settings  # type: ignore[attr-defined]
+    original_root = run.ROOT
+    original_env = dict(os.environ)
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    (tests_dir / "diagnostics.sh").write_text(
+        "printf '%s\\n' \"$TENZIR_EXEC__DUMP_DIAGNOSTICS\"\n",
+        encoding="utf-8",
+    )
+    (tests_dir / "diagnostics.txt").write_text("true\n", encoding="utf-8")
+    monkeypatch.setenv("TENZIR_BINARY", "/usr/bin/true")
+    monkeypatch.setenv("TENZIR_NODE_BINARY", "/usr/bin/true")
+    monkeypatch.chdir(tmp_path)
+    run._HOOK_LOAD_CACHE.clear()  # type: ignore[attr-defined]
+
+    try:
+        result = run.execute(root=tmp_path, tests=[])
+    finally:
+        run._HOOK_LOAD_CACHE.clear()  # type: ignore[attr-defined]
+        os.environ.clear()
+        os.environ.update(original_env)
+        _restore_runtime(original_settings, original_root)
+
+    assert result.exit_code == 0

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -510,3 +510,37 @@ def test_shutdown_after_late_failure_receives_accumulated_summary(
         _restore_runtime(original_settings, original_root)
 
     assert log_path.read_text(encoding="utf-8") == "1"
+
+
+def test_fixture_mode_invokes_shutdown_hooks_after_pre_activation_failure(
+    tmp_path: Path, monkeypatch
+) -> None:
+    original_settings = run._settings  # type: ignore[attr-defined]
+    original_root = run.ROOT
+    hooks_dir = tmp_path / "hooks"
+    hooks_dir.mkdir()
+    log_path = tmp_path / "shutdown.log"
+    (hooks_dir / "__init__.py").write_text(
+        "from tenzir_test import hooks\n"
+        "@hooks.shutdown\n"
+        "def shutdown(ctx):\n"
+        f"    open({str(log_path)!r}, 'w').write(str(ctx.exit_code))\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(run, "_wait_for_fixture_shutdown", lambda: None)
+    run._HOOK_LOAD_CACHE.clear()  # type: ignore[attr-defined]
+
+    try:
+        with pytest.raises(run.HarnessError, match="is not registered"):
+            run.run_fixture_mode_cli(
+                root=tmp_path,
+                package_dirs=(),
+                fixtures=("unknown_fixture",),
+                debug=False,
+                keep_tmp_dirs=False,
+            )
+    finally:
+        run._HOOK_LOAD_CACHE.clear()  # type: ignore[attr-defined]
+        _restore_runtime(original_settings, original_root)
+
+    assert log_path.read_text(encoding="utf-8") == "1"


### PR DESCRIPTION
## 🔍 Problem

- Projects need a stable way to run local setup code before `tenzir-test` resolves binaries and builds the execution plan.
- The immediate use case is selecting `tenzir` and `tenzir-node` from a local build without wrapping every invocation in shell setup.

## 🛠️ Solution

- Add project-root Python hooks with lifecycle events for invocation, project, and test execution.
- Run `startup` before settings discovery so hooks can update `PATH`, `TENZIR_BINARY`, and `TENZIR_NODE_BINARY`.
- Add project-scoped environment overlays, ordered root/satellite hook chains, failure hooks before tmp cleanup, and `--no-hooks` / `TENZIR_TEST_DISABLE_HOOKS` for recovery.

## 💬 Review

- Check the hook ordering around root and satellite projects.
- Check the tmp-dir cleanup deferral for failure hooks and runner compatibility.
- Documentation is in the companion docs PR.

<sub>
📚 Docs PR: tenzir/docs#284
</sub>
