### PR TITLE
Handle suite fixture failures

### DIFF
--- a/changelog/unreleased/suite-fixture-failure-reporting.md
+++ b/changelog/unreleased/suite-fixture-failure-reporting.md
@@ -1,0 +1,13 @@
+---
+title: Suite fixture failure reporting
+type: bugfix
+authors:
+  - mavam
+  - codex
+pr: 38
+created: 2026-04-29T10:34:23.70897Z
+---
+
+Suite-scoped fixture setup and teardown failures now appear as regular test failures instead of aborting the entire run with a Python traceback.
+
+This lets the harness continue with independent queued tests after a fixture assertion or cleanup error.

--- a/src/tenzir_test/fixtures/__init__.py
+++ b/src/tenzir_test/fixtures/__init__.py
@@ -868,7 +868,13 @@ def suite_scope(names: Iterable[FixtureSpec | str]) -> Iterator[dict[str, str]]:
 
     context_token = _push_fixture_options_context(normalized)
     stack = ExitStack()
-    combined = _activate_into_stack(normalized, stack)
+    try:
+        combined = _activate_into_stack(normalized, stack)
+    except BaseException:
+        stack.close()
+        if context_token is not None:
+            _CONTEXT.reset(context_token)
+        raise
     scope = _SuiteScope(fixtures=normalized, stack=stack, env=combined)
     token = _SUITE_SCOPE.set(scope)
     try:

--- a/src/tenzir_test/run.py
+++ b/src/tenzir_test/run.py
@@ -5376,6 +5376,42 @@ class Worker:
             summary.record_fixture_outcome(_fixture_names(suite_item.fixtures), False)
         summary.failed += 1
         summary.failed_paths.append(rel_path)
+        finish_ctx = hooks_impl.TestFinishContext(
+            root=self._hook_root,
+            project=self._project_view,
+            test=test_item.path,
+            runner=test_item.runner.name,
+            outcome="failed",
+            reason=message,
+            attempts=0,
+            duration=0.0,
+            fixtures=_fixture_views(suite_item.fixtures),
+            suite=hooks_impl.SuiteView(
+                name=suite_item.suite.name,
+                directory=suite_item.suite.directory,
+            ),
+            tmp_dir=None,
+            update=self._update,
+            coverage=self._coverage,
+        )
+        _invoke_hooks(
+            self._hook_chain,
+            "test_finish",
+            finish_ctx,
+            reverse=True,
+            project_root=self._hook_root,
+            test_path=test_item.path,
+            debug=self._debug,
+        )
+        _invoke_hooks(
+            self._hook_chain,
+            "test_failure",
+            _finish_context_to_failure_context(finish_ctx),
+            reverse=True,
+            project_root=self._hook_root,
+            test_path=test_item.path,
+            debug=self._debug,
+        )
 
     def _run_suite(self, suite_item: SuiteQueueItem, summary: Summary) -> None:
         suite_priority_released = False
@@ -5540,7 +5576,7 @@ class Worker:
                     suite_item.suite.name,
                     reason,
                 )
-            except HarnessError:
+            except (HarnessError, hooks_impl.HookInvocationError):
                 raise
             except Exception as exc:
                 detail = _sanitize_message(str(exc)).strip() or exc.__class__.__name__

--- a/src/tenzir_test/run.py
+++ b/src/tenzir_test/run.py
@@ -5367,11 +5367,9 @@ class Worker:
         summary: Summary,
         message: str,
     ) -> None:
-        test_item = suite_item.tests[0]
-        report_failure(test_item.path, format_failure_message(message))
-        rel_path = _relativize_path(test_item.path)
-        summary.total += 1
-        summary.record_runner_outcome(test_item.runner.name, False)
+        suite_failure_path = suite_item.suite.directory / _CONFIG_FILE_NAME
+        report_failure(suite_failure_path, format_failure_message(message))
+        rel_path = _relativize_path(suite_failure_path)
         if suite_item.fixtures:
             summary.record_fixture_outcome(_fixture_names(suite_item.fixtures), False)
         summary.failed += 1
@@ -5379,8 +5377,8 @@ class Worker:
         finish_ctx = hooks_impl.TestFinishContext(
             root=self._hook_root,
             project=self._project_view,
-            test=test_item.path,
-            runner=test_item.runner.name,
+            test=suite_failure_path,
+            runner="suite",
             outcome="failed",
             reason=message,
             attempts=0,
@@ -5400,7 +5398,7 @@ class Worker:
             finish_ctx,
             reverse=True,
             project_root=self._hook_root,
-            test_path=test_item.path,
+            test_path=suite_failure_path,
             debug=self._debug,
         )
         _invoke_hooks(
@@ -5409,7 +5407,7 @@ class Worker:
             _finish_context_to_failure_context(finish_ctx),
             reverse=True,
             project_root=self._hook_root,
-            test_path=test_item.path,
+            test_path=suite_failure_path,
             debug=self._debug,
         )
 

--- a/src/tenzir_test/run.py
+++ b/src/tenzir_test/run.py
@@ -27,7 +27,7 @@ import time
 import typing
 from collections.abc import Iterable, Iterator, Mapping, MutableMapping, Sequence
 from pathlib import Path
-from types import ModuleType
+from types import ModuleType, TracebackType
 from typing import Any, Literal, TypeVar, cast, overload
 
 import yaml
@@ -5540,22 +5540,9 @@ class Worker:
             )
             _log_suite_event(suite_item.suite, event="setup", total=total)
             interrupted = False
+            suite_scope = fixtures_impl.suite_scope(suite_item.fixtures)
             try:
-                with fixtures_impl.suite_scope(suite_item.fixtures):
-                    if suite_item.suite.mode is SuiteExecutionMode.PARALLEL:
-                        interrupted = self._run_suite_parallel(
-                            suite_item=suite_item,
-                            tests=tests,
-                            summary=summary,
-                            release_suite_priority=release_suite_priority,
-                        )
-                    else:
-                        release_suite_priority()
-                        interrupted = self._run_suite_sequential(
-                            suite_item=suite_item,
-                            tests=tests,
-                            summary=summary,
-                        )
+                suite_scope.__enter__()
             except fixtures_impl.FixtureUnavailable as exc:
                 if not (
                     isinstance(skip_cfg, SkipConfig)
@@ -5591,6 +5578,58 @@ class Worker:
                     detail,
                 )
                 _CLI_LOGGER.debug("suite fixture failure details", exc_info=True)
+            else:
+                body_exc: BaseException | None = None
+                body_tb: TracebackType | None = None
+                try:
+                    if suite_item.suite.mode is SuiteExecutionMode.PARALLEL:
+                        interrupted = self._run_suite_parallel(
+                            suite_item=suite_item,
+                            tests=tests,
+                            summary=summary,
+                            release_suite_priority=release_suite_priority,
+                        )
+                    else:
+                        release_suite_priority()
+                        interrupted = self._run_suite_sequential(
+                            suite_item=suite_item,
+                            tests=tests,
+                            summary=summary,
+                        )
+                except BaseException as exc:
+                    body_exc = exc
+                    body_tb = exc.__traceback__
+                try:
+                    if body_exc is None:
+                        suite_scope.__exit__(None, None, None)
+                    else:
+                        suppress = suite_scope.__exit__(type(body_exc), body_exc, body_tb)
+                        if not suppress:
+                            raise body_exc.with_traceback(body_tb)
+                except (HarnessError, hooks_impl.HookInvocationError):
+                    if body_exc is not None:
+                        body_exc.add_note("additionally, suite fixture teardown failed")
+                        raise body_exc.with_traceback(body_tb)
+                    raise
+                except Exception as exc:
+                    if body_exc is not None:
+                        body_exc.add_note(
+                            "additionally, suite fixture teardown failed: "
+                            f"{_sanitize_message(str(exc))}"
+                        )
+                        raise body_exc.with_traceback(body_tb) from exc
+                    detail = _sanitize_message(str(exc)).strip() or exc.__class__.__name__
+                    self._record_suite_failure(
+                        suite_item=suite_item,
+                        summary=summary,
+                        message=f"suite fixture failed: {detail}",
+                    )
+                    _CLI_LOGGER.warning(
+                        "suite fixture failed for suite '%s': %s",
+                        suite_item.suite.name,
+                        detail,
+                    )
+                    _CLI_LOGGER.debug("suite fixture failure details", exc_info=True)
             finally:
                 _log_suite_event(suite_item.suite, event="teardown", total=total)
                 fixtures_impl.pop_context(context_token)

--- a/src/tenzir_test/run.py
+++ b/src/tenzir_test/run.py
@@ -5597,37 +5597,38 @@ class Worker:
                 except BaseException as exc:
                     body_exc = exc
                     body_tb = exc.__traceback__
-                try:
-                    if body_exc is None:
+                if body_exc is None:
+                    try:
                         suite_scope.__exit__(None, None, None)
-                    else:
+                    except (HarnessError, hooks_impl.HookInvocationError):
+                        raise
+                    except Exception as exc:
+                        detail = _sanitize_message(str(exc)).strip() or exc.__class__.__name__
+                        self._record_suite_failure(
+                            suite_item=suite_item,
+                            summary=summary,
+                            message=f"suite fixture failed: {detail}",
+                        )
+                        _CLI_LOGGER.warning(
+                            "suite fixture failed for suite '%s': %s",
+                            suite_item.suite.name,
+                            detail,
+                        )
+                        _CLI_LOGGER.debug("suite fixture failure details", exc_info=True)
+                else:
+                    try:
                         suppress = suite_scope.__exit__(type(body_exc), body_exc, body_tb)
-                        if not suppress:
-                            raise body_exc.with_traceback(body_tb)
-                except (HarnessError, hooks_impl.HookInvocationError):
-                    if body_exc is not None:
+                    except (HarnessError, hooks_impl.HookInvocationError):
                         body_exc.add_note("additionally, suite fixture teardown failed")
                         raise body_exc.with_traceback(body_tb)
-                    raise
-                except Exception as exc:
-                    if body_exc is not None:
+                    except Exception as exc:
                         body_exc.add_note(
                             "additionally, suite fixture teardown failed: "
                             f"{_sanitize_message(str(exc))}"
                         )
                         raise body_exc.with_traceback(body_tb) from exc
-                    detail = _sanitize_message(str(exc)).strip() or exc.__class__.__name__
-                    self._record_suite_failure(
-                        suite_item=suite_item,
-                        summary=summary,
-                        message=f"suite fixture failed: {detail}",
-                    )
-                    _CLI_LOGGER.warning(
-                        "suite fixture failed for suite '%s': %s",
-                        suite_item.suite.name,
-                        detail,
-                    )
-                    _CLI_LOGGER.debug("suite fixture failure details", exc_info=True)
+                    if not suppress:
+                        raise body_exc.with_traceback(body_tb)
             finally:
                 _log_suite_event(suite_item.suite, event="teardown", total=total)
                 fixtures_impl.pop_context(context_token)

--- a/src/tenzir_test/run.py
+++ b/src/tenzir_test/run.py
@@ -5360,6 +5360,23 @@ class Worker:
         _merge_summary_inplace(summary, suite_summary)
         return interrupted
 
+    def _record_suite_failure(
+        self,
+        *,
+        suite_item: SuiteQueueItem,
+        summary: Summary,
+        message: str,
+    ) -> None:
+        test_item = suite_item.tests[0]
+        report_failure(test_item.path, format_failure_message(message))
+        rel_path = _relativize_path(test_item.path)
+        summary.total += 1
+        summary.record_runner_outcome(test_item.runner.name, False)
+        if suite_item.fixtures:
+            summary.record_fixture_outcome(_fixture_names(suite_item.fixtures), False)
+        summary.failed += 1
+        summary.failed_paths.append(rel_path)
+
     def _run_suite(self, suite_item: SuiteQueueItem, summary: Summary) -> None:
         suite_priority_released = False
 
@@ -5523,6 +5540,21 @@ class Worker:
                     suite_item.suite.name,
                     reason,
                 )
+            except HarnessError:
+                raise
+            except Exception as exc:
+                detail = _sanitize_message(str(exc)).strip() or exc.__class__.__name__
+                self._record_suite_failure(
+                    suite_item=suite_item,
+                    summary=summary,
+                    message=f"suite fixture failed: {detail}",
+                )
+                _CLI_LOGGER.warning(
+                    "suite fixture failed for suite '%s': %s",
+                    suite_item.suite.name,
+                    detail,
+                )
+                _CLI_LOGGER.debug("suite fixture failure details", exc_info=True)
             finally:
                 _log_suite_event(suite_item.suite, event="teardown", total=total)
                 fixtures_impl.pop_context(context_token)

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -670,7 +670,7 @@ def test_worker_suite_fixture_teardown_failure_is_reported_and_queue_continues(
         worker.start()
         summary = worker.join()
         assert worker._exception is None
-        assert summary.total == 3
+        assert summary.total == 2
         assert summary.failed == 1
         assert set(executed) == {
             Path("tests/context/01-suite.tql"),
@@ -735,16 +735,18 @@ def test_worker_suite_fixture_teardown_failure_invokes_failure_hooks(
         def run(self, test: Path, update: bool, coverage: bool = False) -> bool:  # noqa: ARG002
             return True
 
-    finish_events: list[tuple[str, str | None, str | None]] = []
-    failure_events: list[tuple[str | None, str | None]] = []
+    finish_events: list[tuple[str, str | None, str | None, Path, str]] = []
+    failure_events: list[tuple[str | None, str | None, Path, str]] = []
 
     def finish(ctx: hooks.TestFinishContext) -> None:
         suite_name = ctx.suite.name if ctx.suite else None
-        finish_events.append((ctx.outcome, ctx.reason, suite_name))
+        finish_events.append(
+            (ctx.outcome, ctx.reason, suite_name, ctx.test.relative_to(tmp_path), ctx.runner)
+        )
 
     def failure(ctx: hooks.TestFailureContext) -> None:
         suite_name = ctx.suite.name if ctx.suite else None
-        failure_events.append((ctx.reason, suite_name))
+        failure_events.append((ctx.reason, suite_name, ctx.test.relative_to(tmp_path), ctx.runner))
 
     runner = RecordingRunner()
     queue: list[run.RunnerQueueItem] = [
@@ -773,13 +775,26 @@ def test_worker_suite_fixture_teardown_failure_invokes_failure_hooks(
             fixture_api._FACTORIES["hook_teardown_fixture"] = previous_factory
         run.apply_settings(original_settings)
 
-    assert summary.total == 2
+    assert summary.total == 1
     assert summary.failed == 1
     assert finish_events == [
-        ("passed", None, "context"),
-        ("failed", "suite fixture failed: teardown exploded", "context"),
+        ("passed", None, "context", Path("tests/context/01-suite.tql"), "recording"),
+        (
+            "failed",
+            "suite fixture failed: teardown exploded",
+            "context",
+            Path("tests/context/test.yaml"),
+            "suite",
+        ),
     ]
-    assert failure_events == [("suite fixture failed: teardown exploded", "context")]
+    assert failure_events == [
+        (
+            "suite fixture failed: teardown exploded",
+            "context",
+            Path("tests/context/test.yaml"),
+            "suite",
+        )
+    ]
 
 
 def test_worker_suite_hook_failure_propagates_instead_of_becoming_fixture_failure(

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -688,6 +688,167 @@ def test_worker_suite_fixture_teardown_failure_is_reported_and_queue_continues(
         run.apply_settings(original_settings)
 
 
+def test_worker_suite_fixture_teardown_failure_invokes_failure_hooks(
+    tmp_path: Path,
+) -> None:
+    original_settings = config.Settings(
+        root=run.ROOT,
+        tenzir_binary=run.TENZIR_BINARY,
+        tenzir_node_binary=run.TENZIR_NODE_BINARY,
+    )
+    run.apply_settings(
+        config.Settings(
+            root=tmp_path,
+            tenzir_binary=run.TENZIR_BINARY,
+            tenzir_node_binary=run.TENZIR_NODE_BINARY,
+        )
+    )
+    suite_dir = tmp_path / "tests" / "context"
+    suite_dir.mkdir(parents=True)
+    (suite_dir / "test.yaml").write_text(
+        "suite: context\nfixtures:\n  - hook_teardown_fixture\n", encoding="utf-8"
+    )
+    suite_test = suite_dir / "01-suite.tql"
+    suite_test.write_text("version\nwrite_json\n", encoding="utf-8")
+
+    previous_factory = fixture_api._FACTORIES.get("hook_teardown_fixture")
+
+    @fixture_api.fixture(name="hook_teardown_fixture", replace=True)
+    def hook_teardown_fixture():
+        try:
+            yield {}
+        finally:
+            raise RuntimeError("teardown exploded")
+
+    class RecordingRunner(Runner):
+        def __init__(self) -> None:
+            super().__init__(name="recording")
+
+        def collect_tests(self, path: Path) -> set[tuple[Runner, Path]]:
+            if path.is_file():
+                return {(self, path)}
+            return set()
+
+        def purge(self) -> None:
+            return
+
+        def run(self, test: Path, update: bool, coverage: bool = False) -> bool:  # noqa: ARG002
+            return True
+
+    finish_events: list[tuple[str, str | None, str | None]] = []
+    failure_events: list[tuple[str | None, str | None]] = []
+
+    def finish(ctx: hooks.TestFinishContext) -> None:
+        suite_name = ctx.suite.name if ctx.suite else None
+        finish_events.append((ctx.outcome, ctx.reason, suite_name))
+
+    def failure(ctx: hooks.TestFailureContext) -> None:
+        suite_name = ctx.suite.name if ctx.suite else None
+        failure_events.append((ctx.reason, suite_name))
+
+    runner = RecordingRunner()
+    queue: list[run.RunnerQueueItem] = [
+        run.SuiteQueueItem(
+            suite=run.SuiteInfo(name="context", directory=suite_dir),
+            tests=[run.TestQueueItem(runner=runner, path=suite_test)],
+            fixtures=(fixture_api.FixtureSpec("hook_teardown_fixture"),),
+        ),
+    ]
+    try:
+        worker = run.Worker(
+            queue,
+            update=False,
+            coverage=False,
+            hook_chain=(hooks.HookSet(test_finish=[finish], test_failure=[failure]),),
+            project_view=hooks.ProjectView(root=tmp_path, kind="root"),
+            hook_root=tmp_path,
+        )
+        worker.start()
+        summary = worker.join()
+    finally:
+        run._clear_directory_config_cache()
+        if previous_factory is None:
+            fixture_api._FACTORIES.pop("hook_teardown_fixture", None)
+        else:
+            fixture_api._FACTORIES["hook_teardown_fixture"] = previous_factory
+        run.apply_settings(original_settings)
+
+    assert summary.total == 2
+    assert summary.failed == 1
+    assert finish_events == [
+        ("passed", None, "context"),
+        ("failed", "suite fixture failed: teardown exploded", "context"),
+    ]
+    assert failure_events == [("suite fixture failed: teardown exploded", "context")]
+
+
+def test_worker_suite_hook_failure_propagates_instead_of_becoming_fixture_failure(
+    tmp_path: Path,
+) -> None:
+    original_settings = config.Settings(
+        root=run.ROOT,
+        tenzir_binary=run.TENZIR_BINARY,
+        tenzir_node_binary=run.TENZIR_NODE_BINARY,
+    )
+    run.apply_settings(
+        config.Settings(
+            root=tmp_path,
+            tenzir_binary=run.TENZIR_BINARY,
+            tenzir_node_binary=run.TENZIR_NODE_BINARY,
+        )
+    )
+    suite_dir = tmp_path / "tests" / "context"
+    suite_dir.mkdir(parents=True)
+    (suite_dir / "test.yaml").write_text("suite: context\n", encoding="utf-8")
+    suite_test = suite_dir / "01-suite.tql"
+    suite_test.write_text("version\nwrite_json\n", encoding="utf-8")
+
+    class RecordingRunner(Runner):
+        def __init__(self) -> None:
+            super().__init__(name="recording")
+
+        def collect_tests(self, path: Path) -> set[tuple[Runner, Path]]:
+            if path.is_file():
+                return {(self, path)}
+            return set()
+
+        def purge(self) -> None:
+            return
+
+        def run(self, test: Path, update: bool, coverage: bool = False) -> bool:  # noqa: ARG002
+            return True
+
+    def start(ctx: hooks.TestStartContext) -> None:  # noqa: ARG001
+        raise RuntimeError("start hook exploded")
+
+    runner = RecordingRunner()
+    queue: list[run.RunnerQueueItem] = [
+        run.SuiteQueueItem(
+            suite=run.SuiteInfo(name="context", directory=suite_dir),
+            tests=[run.TestQueueItem(runner=runner, path=suite_test)],
+            fixtures=(),
+        ),
+    ]
+    try:
+        worker = run.Worker(
+            queue,
+            update=False,
+            coverage=False,
+            hook_chain=(hooks.HookSet(test_start=[start]),),
+            project_view=hooks.ProjectView(root=tmp_path, kind="root"),
+            hook_root=tmp_path,
+        )
+        worker.start()
+        with pytest.raises(hooks.HookInvocationError, match="start hook exploded"):
+            worker.join()
+    finally:
+        run._clear_directory_config_cache()
+        run.apply_settings(original_settings)
+
+    assert worker._exception is not None
+    assert worker.partial_summary.total == 0
+
+
 def test_worker_runs_parallel_suite_concurrently(tmp_path: Path) -> None:
     original_settings = config.Settings(
         root=run.ROOT,

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -605,6 +605,89 @@ def test_worker_runs_suite_sequentially(monkeypatch: pytest.MonkeyPatch, tmp_pat
         run.apply_settings(original_settings)
 
 
+def test_worker_suite_fixture_teardown_failure_is_reported_and_queue_continues(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    original_settings = config.Settings(
+        root=run.ROOT,
+        tenzir_binary=run.TENZIR_BINARY,
+        tenzir_node_binary=run.TENZIR_NODE_BINARY,
+    )
+    run.apply_settings(
+        config.Settings(
+            root=tmp_path,
+            tenzir_binary=run.TENZIR_BINARY,
+            tenzir_node_binary=run.TENZIR_NODE_BINARY,
+        )
+    )
+    suite_dir = tmp_path / "tests" / "context"
+    suite_dir.mkdir(parents=True)
+    (suite_dir / "test.yaml").write_text(
+        "suite: context\nfixtures:\n  - failing_teardown_fixture\n", encoding="utf-8"
+    )
+    suite_test = suite_dir / "01-suite.tql"
+    suite_test.write_text("version\nwrite_json\n", encoding="utf-8")
+    standalone_test = tmp_path / "tests" / "standalone.tql"
+    standalone_test.write_text("version\nwrite_json\n", encoding="utf-8")
+
+    executed: list[Path] = []
+    previous_factory = fixture_api._FACTORIES.get("failing_teardown_fixture")
+
+    @fixture_api.fixture(name="failing_teardown_fixture", replace=True)
+    def failing_teardown_fixture():
+        try:
+            yield {}
+        finally:
+            raise RuntimeError("teardown exploded")
+
+    class RecordingRunner(Runner):
+        def __init__(self) -> None:
+            super().__init__(name="recording")
+
+        def collect_tests(self, path: Path) -> set[tuple[Runner, Path]]:
+            if path.is_file():
+                return {(self, path)}
+            return set()
+
+        def purge(self) -> None:
+            return
+
+        def run(self, test: Path, update: bool, coverage: bool = False) -> bool:  # noqa: ARG002
+            executed.append(test.relative_to(tmp_path))
+            return True
+
+    runner = RecordingRunner()
+    queue: list[run.RunnerQueueItem] = [
+        run.SuiteQueueItem(
+            suite=run.SuiteInfo(name="context", directory=suite_dir),
+            tests=[run.TestQueueItem(runner=runner, path=suite_test)],
+            fixtures=(fixture_api.FixtureSpec("failing_teardown_fixture"),),
+        ),
+        run.TestQueueItem(runner=runner, path=standalone_test),
+    ]
+    try:
+        worker = run.Worker(queue, update=False, coverage=False)
+        worker.start()
+        summary = worker.join()
+        assert worker._exception is None
+        assert summary.total == 3
+        assert summary.failed == 1
+        assert set(executed) == {
+            Path("tests/context/01-suite.tql"),
+            Path("tests/standalone.tql"),
+        }
+        output = capsys.readouterr().out
+        assert "suite fixture failed: teardown exploded" in output
+        assert "Traceback" not in output
+    finally:
+        run._clear_directory_config_cache()
+        if previous_factory is None:
+            fixture_api._FACTORIES.pop("failing_teardown_fixture", None)
+        else:
+            fixture_api._FACTORIES["failing_teardown_fixture"] = previous_factory
+        run.apply_settings(original_settings)
+
+
 def test_worker_runs_parallel_suite_concurrently(tmp_path: Path) -> None:
     original_settings = config.Settings(
         root=run.ROOT,

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -849,6 +849,74 @@ def test_worker_suite_hook_failure_propagates_instead_of_becoming_fixture_failur
     assert worker.partial_summary.total == 0
 
 
+def test_worker_suite_body_exception_propagates_and_queue_stops(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    original_settings = config.Settings(
+        root=run.ROOT,
+        tenzir_binary=run.TENZIR_BINARY,
+        tenzir_node_binary=run.TENZIR_NODE_BINARY,
+    )
+    run.apply_settings(
+        config.Settings(
+            root=tmp_path,
+            tenzir_binary=run.TENZIR_BINARY,
+            tenzir_node_binary=run.TENZIR_NODE_BINARY,
+        )
+    )
+    suite_dir = tmp_path / "tests" / "context"
+    suite_dir.mkdir(parents=True)
+    (suite_dir / "test.yaml").write_text("suite: context\n", encoding="utf-8")
+    suite_test = suite_dir / "01-suite.tql"
+    suite_test.write_text("version\nwrite_json\n", encoding="utf-8")
+    standalone_test = tmp_path / "tests" / "standalone.tql"
+    standalone_test.write_text("version\nwrite_json\n", encoding="utf-8")
+
+    executed: list[Path] = []
+
+    class RecordingRunner(Runner):
+        def __init__(self) -> None:
+            super().__init__(name="recording")
+
+        def collect_tests(self, path: Path) -> set[tuple[Runner, Path]]:
+            if path.is_file():
+                return {(self, path)}
+            return set()
+
+        def purge(self) -> None:
+            return
+
+        def run(self, test: Path, update: bool, coverage: bool = False) -> bool:  # noqa: ARG002
+            executed.append(test.relative_to(tmp_path))
+            return True
+
+    def fail_suite_body(*args: object, **kwargs: object) -> bool:
+        raise RuntimeError("suite body exploded")
+
+    monkeypatch.setattr(run.Worker, "_run_suite_sequential", fail_suite_body)
+
+    runner = RecordingRunner()
+    queue: list[run.RunnerQueueItem] = [
+        run.TestQueueItem(runner=runner, path=standalone_test),
+        run.SuiteQueueItem(
+            suite=run.SuiteInfo(name="context", directory=suite_dir),
+            tests=[run.TestQueueItem(runner=runner, path=suite_test)],
+            fixtures=(),
+        ),
+    ]
+    try:
+        worker = run.Worker(queue, update=False, coverage=False)
+        worker.start()
+        with pytest.raises(RuntimeError, match="suite body exploded"):
+            worker.join()
+    finally:
+        run._clear_directory_config_cache()
+        run.apply_settings(original_settings)
+
+    assert executed == []
+    assert worker.partial_summary.total == 0
+
+
 def test_worker_runs_parallel_suite_concurrently(tmp_path: Path) -> None:
     original_settings = config.Settings(
         root=run.ROOT,

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -688,6 +688,99 @@ def test_worker_suite_fixture_teardown_failure_is_reported_and_queue_continues(
         run.apply_settings(original_settings)
 
 
+def test_worker_suite_fixture_setup_failure_closes_already_entered_fixtures(
+    tmp_path: Path,
+) -> None:
+    original_settings = config.Settings(
+        root=run.ROOT,
+        tenzir_binary=run.TENZIR_BINARY,
+        tenzir_node_binary=run.TENZIR_NODE_BINARY,
+    )
+    run.apply_settings(
+        config.Settings(
+            root=tmp_path,
+            tenzir_binary=run.TENZIR_BINARY,
+            tenzir_node_binary=run.TENZIR_NODE_BINARY,
+        )
+    )
+    suite_dir = tmp_path / "tests" / "context"
+    suite_dir.mkdir(parents=True)
+    (suite_dir / "test.yaml").write_text(
+        "suite: context\nfixtures:\n  - entered_fixture\n  - failing_setup_fixture\n",
+        encoding="utf-8",
+    )
+    suite_test = suite_dir / "01-suite.tql"
+    suite_test.write_text("version\nwrite_json\n", encoding="utf-8")
+    standalone_test = tmp_path / "tests" / "standalone.tql"
+    standalone_test.write_text("version\nwrite_json\n", encoding="utf-8")
+
+    counts = {"start": 0, "stop": 0}
+    executed: list[Path] = []
+    previous_entered = fixture_api._FACTORIES.get("entered_fixture")
+    previous_failing = fixture_api._FACTORIES.get("failing_setup_fixture")
+
+    @fixture_api.fixture(name="entered_fixture", replace=True)
+    def entered_fixture():
+        counts["start"] += 1
+        try:
+            yield {}
+        finally:
+            counts["stop"] += 1
+
+    @fixture_api.fixture(name="failing_setup_fixture", replace=True)
+    def failing_setup_fixture():
+        raise RuntimeError("setup exploded")
+        yield {}  # type: ignore[misc]
+
+    class RecordingRunner(Runner):
+        def __init__(self) -> None:
+            super().__init__(name="recording")
+
+        def collect_tests(self, path: Path) -> set[tuple[Runner, Path]]:
+            if path.is_file():
+                return {(self, path)}
+            return set()
+
+        def purge(self) -> None:
+            return
+
+        def run(self, test: Path, update: bool, coverage: bool = False) -> bool:  # noqa: ARG002
+            executed.append(test.relative_to(tmp_path))
+            return True
+
+    runner = RecordingRunner()
+    queue: list[run.RunnerQueueItem] = [
+        run.SuiteQueueItem(
+            suite=run.SuiteInfo(name="context", directory=suite_dir),
+            tests=[run.TestQueueItem(runner=runner, path=suite_test)],
+            fixtures=(
+                fixture_api.FixtureSpec("entered_fixture"),
+                fixture_api.FixtureSpec("failing_setup_fixture"),
+            ),
+        ),
+        run.TestQueueItem(runner=runner, path=standalone_test),
+    ]
+    try:
+        worker = run.Worker(queue, update=False, coverage=False)
+        worker.start()
+        summary = worker.join()
+    finally:
+        run._clear_directory_config_cache()
+        if previous_entered is None:
+            fixture_api._FACTORIES.pop("entered_fixture", None)
+        else:
+            fixture_api._FACTORIES["entered_fixture"] = previous_entered
+        if previous_failing is None:
+            fixture_api._FACTORIES.pop("failing_setup_fixture", None)
+        else:
+            fixture_api._FACTORIES["failing_setup_fixture"] = previous_failing
+        run.apply_settings(original_settings)
+
+    assert summary.failed == 1
+    assert counts == {"start": 1, "stop": 1}
+    assert executed == [Path("tests/standalone.tql")]
+
+
 def test_worker_suite_fixture_teardown_failure_invokes_failure_hooks(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -922,7 +922,7 @@ def test_worker_suite_body_exception_propagates_and_queue_stops(
     try:
         worker = run.Worker(queue, update=False, coverage=False)
         worker.start()
-        with pytest.raises(RuntimeError, match="suite body exploded"):
+        with pytest.raises(RuntimeError, match="suite body exploded") as exc_info:
             worker.join()
     finally:
         run._clear_directory_config_cache()
@@ -930,6 +930,9 @@ def test_worker_suite_body_exception_propagates_and_queue_stops(
 
     assert executed == []
     assert worker.partial_summary.total == 0
+    assert not any(
+        "suite fixture teardown failed" in note for note in getattr(exc_info.value, "__notes__", ())
+    )
 
 
 def test_worker_runs_parallel_suite_concurrently(tmp_path: Path) -> None:


### PR DESCRIPTION
## 🔍 Problem

- Exceptions raised by suite-scoped fixture setup or teardown escaped the worker.
- A single bad fixture assertion could abort the entire test run with a Python traceback instead of reporting a normal failure.

## 🛠️ Solution

- Convert suite fixture exceptions into regular suite failures.
- Keep independent queued tests running after the failed suite.
- Preserve explicit harness errors and fixture-unavailable skip handling.

## 💬 Review

- Check whether counting the suite-level fixture failure against the first suite test is the right reporting granularity.
- The regression test covers teardown failures, traceback suppression, and continued queue execution.
