### PR TITLE
Fix suite requirement checks for mixed runners

### DIFF
--- a/changelog/unreleased/runner-independent-suite-requirements.md
+++ b/changelog/unreleased/runner-independent-suite-requirements.md
@@ -4,7 +4,8 @@ type: bugfix
 authors:
   - mavam
   - codex
-created: 2026-04-29T16:26:05.521123Z
+pr: 39
+created: 2026-04-29T16:27:17.000323Z
 ---
 
 Suite-level `requires.operators` checks now apply consistently to every test runner. Mixed suites that combine TQL, shell, Python, or custom tests no longer depend on the first runner type to decide whether required Tenzir operators are available.

--- a/changelog/unreleased/runner-independent-suite-requirements.md
+++ b/changelog/unreleased/runner-independent-suite-requirements.md
@@ -1,0 +1,10 @@
+---
+title: Runner-independent suite requirements
+type: bugfix
+authors:
+  - mavam
+  - codex
+created: 2026-04-29T16:26:05.521123Z
+---
+
+Suite-level `requires.operators` checks now apply consistently to every test runner. Mixed suites that combine TQL, shell, Python, or custom tests no longer depend on the first runner type to decide whether required Tenzir operators are available.

--- a/src/tenzir_test/run.py
+++ b/src/tenzir_test/run.py
@@ -5124,7 +5124,7 @@ class Worker:
     ) -> bool:
         if not TENZIR_BINARY:
             raise RuntimeError(
-                "TENZIR_BINARY must be configured before evaluating suite requirements"
+                "TENZIR_BINARY must be configured before checking required TQL operators"
             )
         cache_key = (operator, tuple(config_args))
         if cache_key in self._operator_requirement_cache:

--- a/src/tenzir_test/run.py
+++ b/src/tenzir_test/run.py
@@ -246,9 +246,6 @@ class RequiresConfig:
     def has_requirements(self) -> bool:
         return bool(self.operators)
 
-    def as_mapping(self) -> dict[str, tuple[str, ...]]:
-        return {"operators": self.operators}
-
     @classmethod
     def from_raw(
         cls,
@@ -4871,6 +4868,7 @@ class Worker:
         self._project_view = project_view or hooks_impl.ProjectView(
             root=self._hook_root, kind="root"
         )
+        self._operator_requirement_cache: dict[tuple[str, tuple[str, ...]], bool] = {}
         self._thread = threading.Thread(target=self._work)
 
     def __del__(self) -> None:
@@ -5117,6 +5115,35 @@ class Worker:
             )
         return True
 
+    def _is_operator_available(
+        self,
+        operator: str,
+        *,
+        env: Mapping[str, str],
+        config_args: Sequence[str],
+    ) -> bool:
+        if not TENZIR_BINARY:
+            raise RuntimeError(
+                "TENZIR_BINARY must be configured before evaluating suite requirements"
+            )
+        cache_key = (operator, tuple(config_args))
+        if cache_key in self._operator_requirement_cache:
+            return self._operator_requirement_cache[cache_key]
+        escaped = operator.replace("\\", "\\\\").replace('"', '\\"')
+        probe = f'plugins | where name == "{escaped}"'
+        completed = run_subprocess(
+            [*TENZIR_BINARY, *config_args, probe],
+            env=dict(env),
+            capture_output=True,
+            check=False,
+            force_capture=True,
+            cwd=str(ROOT),
+        )
+        stdout = completed.stdout or b""
+        result = bool(stdout.strip())
+        self._operator_requirement_cache[cache_key] = result
+        return result
+
     def _evaluate_suite_requirements(
         self,
         *,
@@ -5126,39 +5153,19 @@ class Worker:
         env: Mapping[str, str],
         config_args: Sequence[str],
     ) -> str | None:
-        requirements = requires.as_mapping()
-        missing_by_key: dict[str, set[str]] = {}
-        unsupported_by_key: dict[str, set[str]] = {}
-        for runner in {test_item.runner for test_item in tests}:
-            result = runner.check_requirements(
-                requirements,
+        del suite_item, tests
+        missing_operators = [
+            operator
+            for operator in requires.operators
+            if not self._is_operator_available(
+                operator,
                 env=env,
                 config_args=config_args,
             )
-            for key in result.unsupported_keys:
-                unsupported_by_key.setdefault(key, set()).add(runner.name)
-            for key, required_values in result.missing_values.items():
-                if not required_values:
-                    continue
-                missing_by_key.setdefault(key, set()).update(required_values)
-        if unsupported_by_key:
-            detail = ", ".join(
-                f"{key} (runners: {', '.join(sorted(runners))})"
-                for key, runners in sorted(unsupported_by_key.items())
-            )
-            raise HarnessError(
-                f"suite '{suite_item.suite.name}' has unsupported requirement categories: {detail}"
-            )
-        if not missing_by_key:
+        ]
+        if not missing_operators:
             return None
-        parts: list[str] = []
-        for key, missing_set in sorted(missing_by_key.items()):
-            rendered_values = ", ".join(sorted(missing_set))
-            if key == "operators":
-                parts.append(f"missing operators: {rendered_values}")
-            else:
-                parts.append(f"missing {key}: {rendered_values}")
-        return "; ".join(parts)
+        return f"missing operators: {', '.join(sorted(missing_operators))}"
 
     def _suite_static_skip_plan(
         self, suite_item: SuiteQueueItem

--- a/src/tenzir_test/runners/runner.py
+++ b/src/tenzir_test/runners/runner.py
@@ -1,17 +1,7 @@
 from __future__ import annotations
 
-import dataclasses
-from collections.abc import Mapping, Sequence
 from abc import ABC, abstractmethod
 from pathlib import Path
-
-
-@dataclasses.dataclass(frozen=True, slots=True)
-class RequirementCheckResult:
-    """Outcome of evaluating suite requirements for a runner."""
-
-    unsupported_keys: tuple[str, ...] = tuple()
-    missing_values: dict[str, tuple[str, ...]] = dataclasses.field(default_factory=dict)
 
 
 class Runner(ABC):
@@ -44,20 +34,5 @@ class Runner(ABC):
     def run(self, test: Path, update: bool, coverage: bool = False) -> bool | str:
         raise NotImplementedError
 
-    def check_requirements(
-        self,
-        requirements: Mapping[str, Sequence[str]],
-        *,
-        env: Mapping[str, str],
-        config_args: Sequence[str],
-    ) -> RequirementCheckResult:
-        """Return unsupported and missing requirements for this runner.
 
-        Base runners do not expose requirement probes and therefore report all
-        non-empty requirement categories as unsupported.
-        """
-        unsupported = tuple(sorted(key for key, values in requirements.items() if values))
-        return RequirementCheckResult(unsupported_keys=unsupported)
-
-
-__all__ = ["Runner", "RequirementCheckResult"]
+__all__ = ["Runner"]

--- a/src/tenzir_test/runners/tql_runner.py
+++ b/src/tenzir_test/runners/tql_runner.py
@@ -1,10 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
-
-from ._utils import get_run_module
 from .ext_runner import ExtRunner
-from .runner import RequirementCheckResult
 
 
 class TqlRunner(ExtRunner):
@@ -12,67 +8,6 @@ class TqlRunner(ExtRunner):
 
     def __init__(self, *, name: str) -> None:
         super().__init__(name=name, ext="tql")
-
-    def _is_operator_available(
-        self,
-        operator: str,
-        *,
-        env: Mapping[str, str],
-        config_args: Sequence[str],
-    ) -> bool:
-        run_mod = get_run_module()
-        binary = run_mod.TENZIR_BINARY
-        if not binary:
-            raise RuntimeError(
-                "TENZIR_BINARY must be configured before evaluating suite requirements"
-            )
-        escaped = operator.replace("\\", "\\\\").replace('"', '\\"')
-        probe = f'plugins | where name == "{escaped}"'
-        completed = run_mod.run_subprocess(
-            [*binary, *config_args, probe],
-            env=dict(env),
-            capture_output=True,
-            check=False,
-            force_capture=True,
-            cwd=str(run_mod.ROOT),
-        )
-        stdout = completed.stdout or b""
-        return bool(stdout.strip())
-
-    def check_requirements(
-        self,
-        requirements: Mapping[str, Sequence[str]],
-        *,
-        env: Mapping[str, str],
-        config_args: Sequence[str],
-    ) -> RequirementCheckResult:
-        unsupported: set[str] = set()
-        missing: dict[str, tuple[str, ...]] = {}
-
-        operators = requirements.get("operators")
-        if operators:
-            missing_ops = [
-                operator
-                for operator in operators
-                if not self._is_operator_available(
-                    operator,
-                    env=env,
-                    config_args=config_args,
-                )
-            ]
-            if missing_ops:
-                missing["operators"] = tuple(missing_ops)
-
-        for key, values in requirements.items():
-            if key == "operators":
-                continue
-            if values:
-                unsupported.add(key)
-
-        return RequirementCheckResult(
-            unsupported_keys=tuple(sorted(unsupported)),
-            missing_values=missing,
-        )
 
 
 __all__ = ["TqlRunner"]

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -5893,7 +5893,7 @@ def test_worker_capability_unavailable_with_multi_skip_conditions(
         run.apply_settings(original_settings)
 
 
-def test_worker_suite_requires_errors_for_unsupported_runner(
+def test_worker_suite_requires_operator_requirements_are_runner_agnostic(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     original_settings = config.Settings(
@@ -5912,26 +5912,39 @@ def test_worker_suite_requires_errors_for_unsupported_runner(
     suite_dir = tmp_path / "tests" / "mixed"
     suite_dir.mkdir(parents=True)
     (suite_dir / "test.yaml").write_text(
-        "suite: mixed\nrequires:\n  operators:\n    - from_gcs\n",
+        "suite: mixed\n"
+        "skip:\n  on: capability-unavailable\n"
+        "requires:\n  operators:\n    - from_gcs\n",
         encoding="utf-8",
     )
     tql_path = suite_dir / "01-test.tql"
     sh_path = suite_dir / "02-test.sh"
+    py_path = suite_dir / "03-test.py"
     tql_path.write_text("version\nwrite_json\n", encoding="utf-8")
     sh_path.write_text("#!/usr/bin/env bash\necho ok\n", encoding="utf-8")
+    py_path.write_text("# runner: python\nprint('ok')\n", encoding="utf-8")
     run._clear_directory_config_cache()
 
+    probes: list[list[str]] = []
+
     def fake_run(cmd, **kwargs):  # noqa: ANN001
-        return SimpleNamespace(returncode=0, stdout=b"present\n", stderr=b"")
+        command = [str(part) for part in cmd]
+        probes.append(command)
+        assert command[0] == "/usr/bin/tenzir"
+        assert command[-1] == 'plugins | where name == "from_gcs"'
+        return SimpleNamespace(returncode=0, stdout=b"", stderr=b"")
 
     monkeypatch.setattr(run.subprocess, "run", fake_run)
 
     try:
-        queue = run._build_queue_from_paths([tql_path, sh_path], coverage=False)
+        queue = run._build_queue_from_paths([tql_path, sh_path, py_path], coverage=False)
         worker = run.Worker(queue, update=False, coverage=False)
         worker.start()
-        with pytest.raises(run.HarnessError, match="unsupported requirement categories: operators"):
-            worker.join()
+        summary = worker.join()
+        assert summary.total == 3
+        assert summary.skipped == 3
+        assert summary.failed == 0
+        assert len(probes) == 1
     finally:
         run._clear_directory_config_cache()
         run.apply_settings(original_settings)


### PR DESCRIPTION
## 🔍 Problem

- Suite-level `requires.operators` checks were tied to runner probing.
- Mixed suites could skip or fail inconsistently depending on which runner handled the capability check.

## 🛠️ Solution

- Evaluate suite requirements once in the worker before activating fixtures or running tests.
- Share the operator availability result across all tests in the suite.
- Remove runner-level requirement probing.

## 💬 Review

- Focus on capability-unavailable skip behavior for mixed TQL/shell/Python suites.
- Quality gates passed: `uv run ruff check`, `uv run ruff format --check`, `uv run mypy`, `uv run pytest`, `uv build`.
