### PR TITLE
Use logger for hook diagnostics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,3 +37,11 @@ The framework supports satellite projects that inherit fixtures and runners from
 ## Documentation
 
 Primary documentation lives at <https://docs.tenzir.com/reference/test.md>.
+
+## Logging
+
+Use the harness logging facilities for diagnostic output instead of ad-hoc
+`print()` calls. In particular, debug output must go through the existing
+`tenzir_test.cli` logger or a module logger configured by the harness, so all
+messages use the same prefixes, colors, synchronization, and verbosity flags.
+Reserve `print()` for intentional user-facing test results and summaries.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,8 +40,5 @@ Primary documentation lives at <https://docs.tenzir.com/reference/test.md>.
 
 ## Logging
 
-Use the harness logging facilities for diagnostic output instead of ad-hoc
-`print()` calls. In particular, debug output must go through the existing
-`tenzir_test.cli` logger or a module logger configured by the harness, so all
-messages use the same prefixes, colors, synchronization, and verbosity flags.
-Reserve `print()` for intentional user-facing test results and summaries.
+Use the harness logging facilities for diagnostic output. Reserve `print()` for
+intentional user-facing test results and summaries.

--- a/changelog/unreleased/consistent-hook-debug-diagnostics.md
+++ b/changelog/unreleased/consistent-hook-debug-diagnostics.md
@@ -1,0 +1,12 @@
+---
+title: Consistent hook debug diagnostics
+type: bugfix
+authors:
+  - mavam
+  - codex
+prs:
+  - 40
+created: 2026-05-05T09:47:13.807224Z
+---
+
+Hook diagnostics emitted with `--debug` now use the same formatting as the rest of the harness debug trace. Previously, hook invocation messages used ad-hoc `debug:` lines, which made debug output inconsistent.

--- a/src/tenzir_test/hooks.py
+++ b/src/tenzir_test/hooks.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import contextvars
 import dataclasses
+import logging
 import os
 from collections.abc import Callable, Iterator, MutableMapping, Sequence
 from pathlib import Path
@@ -290,6 +291,7 @@ class HookInvocationError(RuntimeError):
 
 
 _TEARDOWN_EVENTS: frozenset[HookEvent] = frozenset({"shutdown", "project_finish", "test_finish"})
+_CLI_LOGGER = logging.getLogger("tenzir_test.cli")
 
 
 def invoke(
@@ -311,7 +313,7 @@ def invoke(
             if debug:
                 name = getattr(func, "__qualname__", getattr(func, "__name__", repr(func)))
                 module = getattr(func, "__module__", "<unknown>")
-                print(f"debug: invoking hook {event} {module}.{name}")
+                _CLI_LOGGER.debug("invoking hook %s %s.%s", event, module, name)
             try:
                 cast(Callable[[object], None], func)(context)
             except BaseException as exc:


### PR DESCRIPTION
## 🔍 Problem

- Hook debug diagnostics bypassed the harness logger.
- This produced inconsistent `debug:` output in otherwise standardized `--debug` traces.
- The repository guidance did not explicitly prevent diagnostic `print()` calls.

## 🛠️ Solution

- Route hook debug diagnostics through the existing CLI logger.
- Document that diagnostic output should use harness logging facilities.

## 💬 Review

- Check whether the logging guidance draws the right line between diagnostics and intentional user-facing output.

<sub>
📎 Related: tenzir/tenzir#6118
</sub>
