### PR TITLE
Fix Tenzir version probe

### DIFF
--- a/changelog/unreleased/version-checks-with-current-tql-pipelines.md
+++ b/changelog/unreleased/version-checks-with-current-tql-pipelines.md
@@ -1,0 +1,12 @@
+---
+title: Version checks with current TQL pipelines
+type: bugfix
+authors:
+  - mavam
+  - codex
+prs:
+  - 41
+created: 2026-05-09T09:43:15.038686Z
+---
+
+The test harness can detect the installed Tenzir version with current TQL pipeline semantics. This fixes startup/version checks for Tenzir builds that require output to be routed through an explicit stdout sink.

--- a/changelog/unreleased/version-checks-with-current-tql-pipelines.md
+++ b/changelog/unreleased/version-checks-with-current-tql-pipelines.md
@@ -9,4 +9,4 @@ prs:
 created: 2026-05-09T09:43:15.038686Z
 ---
 
-The test harness can detect the installed Tenzir version with current TQL pipeline semantics. This fixes startup/version checks for Tenzir builds that require output to be routed through an explicit stdout sink.
+The test harness can detect the installed Tenzir version with current TQL pipeline semantics while remaining compatible with existing v5 releases. This fixes startup/version checks for Tenzir builds that require output to be routed through an explicit stdout sink.

--- a/changelog/unreleased/version-checks-with-current-tql-pipelines.md
+++ b/changelog/unreleased/version-checks-with-current-tql-pipelines.md
@@ -9,4 +9,4 @@ prs:
 created: 2026-05-09T09:43:15.038686Z
 ---
 
-The test harness can detect the installed Tenzir version with current TQL pipeline semantics while remaining compatible with existing v5 releases. This fixes startup/version checks for Tenzir builds that require output to be routed through an explicit stdout sink.
+The test harness can detect the installed Tenzir version across current and upcoming Tenzir releases. This keeps startup/version checks working during the transition to the next Tenzir release series.

--- a/src/tenzir_test/run.py
+++ b/src/tenzir_test/run.py
@@ -4274,7 +4274,7 @@ def get_version() -> str:
                 *TENZIR_BINARY,
                 "--bare-mode",
                 "--console-verbosity=warning",
-                "version | select version | write_lines",
+                "version | select version | to_stdout { write_lines }",
             ]
         )
         .decode()

--- a/src/tenzir_test/run.py
+++ b/src/tenzir_test/run.py
@@ -4268,18 +4268,24 @@ def _print_detailed_summary(summary: Summary) -> None:
 def get_version() -> str:
     if not TENZIR_BINARY:
         raise FileNotFoundError("TENZIR_BINARY is not configured")
-    return (
-        subprocess.check_output(
-            [
-                *TENZIR_BINARY,
-                "--bare-mode",
-                "--console-verbosity=warning",
-                "version | select version | to_stdout { write_lines }",
-            ]
-        )
-        .decode()
-        .strip()
-    )
+    command = [
+        *TENZIR_BINARY,
+        "--bare-mode",
+        "--console-verbosity=warning",
+    ]
+    # FIXME: Remove this fallback after tenzir/tenzir has bootstrapped onto a
+    # v6 release candidate and downstream consumers no longer need to run the
+    # harness against v5 binaries. The new probe is required by v6, but v5 only
+    # accepts it with --neo, and --neo no longer exists in v6.
+    for pipeline in (
+        "version | select version | to_stdout { write_lines }",
+        "version | select version | write_lines",
+    ):
+        try:
+            return subprocess.check_output([*command, pipeline]).decode().strip()
+        except subprocess.CalledProcessError:
+            continue
+    raise RuntimeError("failed to detect Tenzir version")
 
 
 def success(test: Path) -> None:


### PR DESCRIPTION
## 🔍 Problem

- The harness version probe needs to work with upcoming Tenzir releases where pipeline output must be routed explicitly.
- `tenzir/tenzir` still needs to consume this harness before that release candidate is published, so the probe cannot become v6-only yet.

## 🛠️ Solution

- Prefer the upcoming-release-compatible version probe.
- Temporarily fall back to the existing v5-compatible probe while the release bootstrap is in progress.
- Add a bugfix changelog entry for the compatibility bridge.

## 💬 Review

- Focus on the temporary fallback and the FIXME describing when it should be removed.