### PR TITLE
Add Lefthook quality gate

### DIFF
--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -1,0 +1,5 @@
+# Keep new worktrees ready to use and install the shared Git hooks.
+pre-start = "uv sync --dev && uv run lefthook install"
+
+# Run the same quality gate before Worktrunk merges as local pushes and CI.
+pre-merge = "uv run lefthook run pre-push --all-files"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,19 +38,12 @@ jobs:
       - name: Install dependencies
         run: uv sync --python ${{ matrix.python-version }} --dev
 
-      - name: Ruff lint
+      - name: Run quality checks
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'
-        run: uv run ruff check
-
-      - name: Ruff format (check)
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'
-        run: uv run ruff format --check
-
-      - name: Type check
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'
-        run: uv run mypy
+        run: uv run lefthook run pre-push --all-files
 
       - name: Run tests
+        if: matrix.os != 'ubuntu-latest' || matrix.python-version != '3.12'
         run: uv run pytest --durations=10
 
   build:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -57,11 +57,7 @@ jobs:
       git-add-paths: pyproject.toml uv.lock
       pre-create: |
         uv sync --dev
-        uv run ruff check
-        uv run ruff format --check
-        uv run mypy
-        uv run pytest
-        uv build
+        uv run lefthook run pre-push --all-files
       post-create: |
         uv lock
       github_app_id: ${{ vars.TENZIR_GITHUB_APP_ID }}

--- a/.pi/npm/.gitignore
+++ b/.pi/npm/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/.pi/settings.json
+++ b/.pi/settings.json
@@ -1,5 +1,0 @@
-{
-  "packages": [
-    "npm:pi-formatter"
-  ]
-}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,3 +42,25 @@ Primary documentation lives at <https://docs.tenzir.com/reference/test.md>.
 
 Use the harness logging facilities for diagnostic output. Reserve `print()` for
 intentional user-facing test results and summaries.
+
+## Development Workflow
+
+Use `uv` for dependencies and virtual environments. Install the shared Git hooks
+after syncing dependencies:
+
+```sh
+uv sync --dev
+uv run lefthook install
+```
+
+Run the shared quality gate before pushing or merging:
+
+```sh
+uv run lefthook run pre-push --all-files
+```
+
+Use the explicit fix hook for formatting and safe lint rewrites:
+
+```sh
+uv run lefthook run fix --all-files
+```

--- a/README.md
+++ b/README.md
@@ -34,6 +34,27 @@ for an end-to-end walkthrough of writing tests.
 We also provide a dense [reference](https://docs.tenzir.com/reference/test) that
 explains concepts, configuration, multi-project execution, and CLI details.
 
+## 🛠️ Development
+
+Install development dependencies and Git hooks with:
+
+```sh
+uv sync --dev
+uv run lefthook install
+```
+
+Run the same quality gate used by CI and local pushes with:
+
+```sh
+uv run lefthook run pre-push --all-files
+```
+
+Apply formatting and safe lint fixes with:
+
+```sh
+uv run lefthook run fix --all-files
+```
+
 ## 📜 License
 
 `tenzir-test` is available under the Apache License, Version 2.0. See

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,21 @@
+pre-push:
+  parallel: true
+  commands:
+    ruff-check:
+      run: uv run ruff check
+    ruff-format:
+      run: uv run ruff format --check
+    mypy:
+      run: uv run mypy
+    pytest:
+      run: uv run pytest --durations=10
+    build:
+      run: uv build
+
+fix:
+  parallel: false
+  commands:
+    ruff-check:
+      run: uv run ruff check --fix
+    ruff-format:
+      run: uv run ruff format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,4 +129,5 @@ dev = [
   "ruff>=0.7.0",
   "coverage[toml]>=7.6.0",
   "types-pyyaml>=6.0.12.20250915",
+  "lefthook>=2.1.6",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -107,6 +107,19 @@ wheels = [
 ]
 
 [[package]]
+name = "lefthook"
+version = "2.1.6"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/1c/95addeea6b681f02cd44e40d8ce970973783f7b48081af88d3831c4f6da6/lefthook-2.1.6-py3-none-macosx_10_15_x86_64.whl", hash = "sha256:6d4608d0bb9dbcf10d333132973941c21bc7cde31a328658611e2066eec26d7e", size = 5439518, upload-time = "2026-04-16T07:34:18.136Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/d4/2c645051bed898f1ad377e7c2e611e0f857502ca76d052db0f8333bb668d/lefthook-2.1.6-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fa6395917dc510c2622f31b6d3992c5506ff2a7569cd9d321712ec29689229b3", size = 4964898, upload-time = "2026-04-16T07:34:13.497Z" },
+    { url = "https://files.pythonhosted.org/packages/19/ea/15b0384c1227ad172af0c18f21f7e00c570ccce086af471ac32edc2cb507/lefthook-2.1.6-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:016295036dd1d94af7ea6604247f0c47102559fb12f97ffcfe7880e8d1ce7a1f", size = 4791370, upload-time = "2026-04-16T07:34:15.04Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/c0/3d43c9e1a08fa79d53f0c6eb808fb0ae9becf29bc7bd89cd757470af040e/lefthook-2.1.6-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:6c00cd91d553e064a2f71c35d2497b4350d1efdf18dd8f2c7ce2b1d6e8e2e147", size = 5367784, upload-time = "2026-04-16T07:34:10.414Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/99/cad1e694989964a8a79b34fdd18e6642bc631e280c06a9341565b5861e3b/lefthook-2.1.6-py3-none-win_amd64.whl", hash = "sha256:e571c48a227f51e5b8aec117c550c6d2ad1f74034e87afd5b0c98cbef319ad3e", size = 5516604, upload-time = "2026-04-16T07:34:12.061Z" },
+    { url = "https://files.pythonhosted.org/packages/85/e9/286657a2c7efbb8701380c4c8a08c54d7f58938a4610d660c463fa074ee3/lefthook-2.1.6-py3-none-win_arm64.whl", hash = "sha256:985b88d908067a6d48a0e89cbc20c18b6a68a3fc4d44387f8ac1c39b85f0f18b", size = 4867769, upload-time = "2026-04-16T07:34:16.757Z" },
+]
+
+[[package]]
 name = "librt"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -350,6 +363,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "coverage" },
+    { name = "lefthook" },
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -366,6 +380,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "coverage", extras = ["toml"], specifier = ">=7.6.0" },
+    { name = "lefthook", specifier = ">=2.1.6" },
     { name = "mypy", specifier = ">=1.11.0" },
     { name = "pytest", specifier = ">=8.3.0" },
     { name = "pytest-cov", specifier = ">=5.0.0" },


### PR DESCRIPTION
## 🔍 Problem

- Local checks, CI, release validation, and worktree automation each encoded their own quality workflow.
- The repo still tracked the obsolete `.pi` formatter setup even though Python tooling already lives in `uv`.

## 🛠️ Solution

- Add a checked-in Lefthook harness for read-only push checks and explicit ruff fixes.
- Route CI, release validation, and Worktrunk merges through the same Lefthook command.
- Document the shared local development commands and remove the stale formatter setup.

## 💬 Review

- Check that `pre-push` should keep `uv build` alongside ruff, mypy, and pytest.
- Check that the CI matrix still gives the intended Python and macOS compatibility coverage while avoiding duplicate Ubuntu 3.12 pytest runs.
