### PR TITLE
Add fixture-name test selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,22 +34,6 @@ for an end-to-end walkthrough of writing tests.
 We also provide a dense [reference](https://docs.tenzir.com/reference/test) that
 explains concepts, configuration, multi-project execution, and CLI details.
 
-## 🎯 Test Selection
-
-Select tests by path, by relative-path pattern, or by requested fixture:
-
-```sh
-tenzir-test tests/alerts --match kafka --fixture-name docker-compose
-tenzir-test --fixture-name node --fixture-name sink
-tenzir-test --fixture-tag container
-```
-
-Repeated `--fixture-name` and `--fixture-tag` values use OR semantics across
-the combined fixture selector. That selector intersects with positional test
-paths and `--match`; if a selected test belongs to a suite, suite expansion
-happens after filtering. The separate `--fixture` option remains standalone
-foreground fixture mode and does not select tests.
-
 ## 🛠️ Development
 
 Install development dependencies and Git hooks with:

--- a/README.md
+++ b/README.md
@@ -34,6 +34,22 @@ for an end-to-end walkthrough of writing tests.
 We also provide a dense [reference](https://docs.tenzir.com/reference/test) that
 explains concepts, configuration, multi-project execution, and CLI details.
 
+## 🎯 Test Selection
+
+Select tests by path, by relative-path pattern, or by requested fixture:
+
+```sh
+tenzir-test tests/alerts --match kafka --fixture-name docker-compose
+tenzir-test --fixture-name node --fixture-name sink
+tenzir-test --fixture-tag container
+```
+
+Repeated `--fixture-name` and `--fixture-tag` values use OR semantics across
+the combined fixture selector. That selector intersects with positional test
+paths and `--match`; if a selected test belongs to a suite, suite expansion
+happens after filtering. The separate `--fixture` option remains standalone
+foreground fixture mode and does not select tests.
+
 ## 🛠️ Development
 
 Install development dependencies and Git hooks with:

--- a/changelog/unreleased/fixture-name-test-selection.md
+++ b/changelog/unreleased/fixture-name-test-selection.md
@@ -1,0 +1,20 @@
+---
+title: Fixture name test selection
+type: feature
+authors:
+  - mavam
+  - codex
+created: 2026-05-12T15:05:31Z
+---
+
+Select tests by requested fixture name with the new `--fixture-name` option:
+
+```sh
+tenzir-test --fixture-name node
+tenzir-test tests/alerts --match kafka --fixture-name docker-compose
+```
+
+`--fixture-name` can be repeated and combines with `--fixture-tag` using OR
+semantics before intersecting with positional test paths and `--match`.
+Fixture selectors are long-only; the previous `-F` alias for `--fixture-tag`
+has been removed before the CLI shape settles.

--- a/src/tenzir_test/cli.py
+++ b/src/tenzir_test/cli.py
@@ -43,7 +43,8 @@ Examples:
                                        Run tests matching either pattern
   tenzir-test tests/ctx/ --match '*create*'
                                        Intersect directory with pattern
-  tenzir-test --fixture-tag container  Run tests using container-backed fixtures
+  tenzir-test --fixture-name node      Run tests requesting a fixture by name
+  tenzir-test --fixture-tag container  Run tests using tagged fixtures
   tenzir-test --run-skipped            Run all skipped tests unconditionally
   tenzir-test --run-skipped-reason maintenance
                                        Run only skipped tests whose reason matches
@@ -216,14 +217,25 @@ Documentation: https://docs.tenzir.com/reference/test-framework/
     ),
 )
 @click.option(
-    "-F",
+    "--fixture-name",
+    "fixture_names",
+    multiple=True,
+    type=str,
+    help=(
+        "Run tests that request a fixture with the given name. "
+        "Repeatable; tests matching any selected fixture name are selected. "
+        "If TEST paths or --match patterns are also given, only tests matching all "
+        "selectors are run (intersection)."
+    ),
+)
+@click.option(
     "--fixture-tag",
     "fixture_tags",
     multiple=True,
     type=str,
     help=(
         "Run tests that request a fixture with the given tag. "
-        "Repeatable; tests matching any tag are selected. "
+        "Repeatable; tests matching any tag or selected fixture name are selected. "
         "If TEST paths or --match patterns are also given, only tests matching all "
         "selectors are run (intersection)."
     ),
@@ -255,6 +267,7 @@ def cli(
     run_skipped_reasons: tuple[str, ...],
     all_projects: bool,
     no_hooks: bool,
+    fixture_names: tuple[str, ...],
     fixture_tags: tuple[str, ...],
 ) -> int:
     """Execute test scenarios and compare output against baselines.
@@ -279,9 +292,11 @@ def cli(
     If a matched test belongs to a suite (configured via test.yaml), all
     tests in that suite are included automatically.
 
-    Use -F/--fixture-tag to select tests by metadata inherited from their
-    requested fixtures. Tags are repeatable and use OR semantics. They
-    intersect with TEST paths and --match patterns.
+    Use --fixture-name and --fixture-tag to select tests by requested fixtures.
+    Fixture names and tags are repeatable and use OR semantics across the
+    combined fixture selector. The fixture selector intersects with TEST paths
+    and --match patterns. Use --fixture for standalone fixture mode, not test
+    selection.
     """
 
     package_paths: list[Path] = []
@@ -333,6 +348,7 @@ def cli(
             jobs_overridden=jobs_overridden,
             all_projects=all_projects,
             match_patterns=list(match_patterns),
+            fixture_names=list(fixture_names),
             fixture_tags=list(fixture_tags),
             no_hooks=no_hooks,
         )

--- a/src/tenzir_test/run.py
+++ b/src/tenzir_test/run.py
@@ -6013,16 +6013,45 @@ def _filter_paths_by_patterns(
     return matched
 
 
-def _filter_paths_by_fixture_tags(
+@dataclasses.dataclass(frozen=True, slots=True)
+class FixtureSelector:
+    names: frozenset[str] = dataclasses.field(default_factory=frozenset)
+    tags: frozenset[str] = dataclasses.field(default_factory=frozenset)
+
+    @classmethod
+    def from_cli(
+        cls,
+        *,
+        names: Sequence[str] = (),
+        tags: Sequence[str] = (),
+    ) -> "FixtureSelector":
+        return cls(
+            names=frozenset(name.strip() for name in names if name and name.strip()),
+            tags=frozenset(tag.strip().lower() for tag in tags if tag and tag.strip()),
+        )
+
+    @property
+    def enabled(self) -> bool:
+        return bool(self.names or self.tags)
+
+    def describe(self) -> str:
+        parts = [f"name={name!r}" for name in sorted(self.names)]
+        parts.extend(f"tag={tag!r}" for tag in sorted(self.tags))
+        return ", ".join(parts)
+
+    def matches(self, spec: fixtures_impl.FixtureSpec) -> bool:
+        return spec.name in self.names or bool(fixtures_impl.get_tags(spec.name) & self.tags)
+
+
+def _filter_paths_by_fixture_selector(
     paths: Iterable[Path],
-    tags: Sequence[str],
+    selector: FixtureSelector,
     *,
     coverage: bool,
 ) -> set[Path]:
-    """Return paths whose configured fixtures have any requested tag."""
+    """Return paths whose configured fixtures match the requested selector."""
 
-    active_tags = frozenset(tag.strip().lower() for tag in tags if tag and tag.strip())
-    if not active_tags:
+    if not selector.enabled:
         return set(paths)
     matched: set[Path] = set()
     for path in paths:
@@ -6036,7 +6065,7 @@ def _filter_paths_by_fixture_tags(
             config.get("fixtures", tuple()),
         )
         for spec in fixture_specs:
-            if fixtures_impl.get_tags(spec.name) & active_tags:
+            if selector.matches(spec):
                 matched.add(path)
                 break
     return matched
@@ -6350,6 +6379,7 @@ def run_cli(
     jobs_overridden: bool = False,
     all_projects: bool = False,
     match_patterns: Sequence[str] = (),
+    fixture_names: Sequence[str] = (),
     fixture_tags: Sequence[str] = (),
     no_hooks: bool = False,
 ) -> ExecutionResult:
@@ -6369,10 +6399,12 @@ def run_cli(
             any pattern are selected.  When path arguments are also provided
             via *tests*, only tests matching both are run (intersection).
             Empty or whitespace-only patterns are silently ignored.
-        fixture_tags: Fixture tags selected by ``-F/--fixture-tag``. Tests
-            matching any tag are selected. When path arguments or
-            *match_patterns* are also provided, only tests matching all
-            selectors are run (intersection).
+        fixture_names: Fixture names selected by ``--fixture-name``. Tests
+            requesting any selected fixture name are selected. Intersects with
+            TEST paths and *match_patterns*.
+        fixture_tags: Fixture tags selected by ``--fixture-tag``. Tests
+            matching any tag are selected. Combined with *fixture_names* using
+            OR semantics, then intersected with TEST paths and *match_patterns*.
     """
     from tenzir_test.engine import state as engine_state
 
@@ -6446,6 +6478,10 @@ def run_cli(
         run_skipped_selector = RunSkippedSelector.from_cli(
             run_all=run_skipped,
             reason_patterns=run_skipped_reasons,
+        )
+        fixture_selector = FixtureSelector.from_cli(
+            names=fixture_names,
+            tags=fixture_tags,
         )
 
         plan: ExecutionPlan | None = None
@@ -6736,25 +6772,24 @@ def run_cli(
                             else:
                                 print(f"{INFO} no tests matched pattern(s): {pattern_list}")
 
-                    active_fixture_tags = [
-                        tag.strip().lower() for tag in fixture_tags if tag and tag.strip()
-                    ]
-                    if active_fixture_tags:
-                        collected_paths = _filter_paths_by_fixture_tags(
+                    if fixture_selector.enabled:
+                        collected_paths = _filter_paths_by_fixture_selector(
                             collected_paths,
-                            active_fixture_tags,
+                            fixture_selector,
                             coverage=coverage,
                         )
                         should_expand_suites = True
                         if not collected_paths:
-                            tag_list = ", ".join(repr(tag) for tag in active_fixture_tags)
+                            selector_list = fixture_selector.describe()
                             if not selection.run_all or active_patterns:
                                 print(
-                                    f"{INFO} no tests matched fixture tag(s) {tag_list}"
+                                    f"{INFO} no tests matched fixture selector(s) {selector_list}"
                                     f" within the selected paths"
                                 )
                             else:
-                                print(f"{INFO} no tests matched fixture tag(s): {tag_list}")
+                                print(
+                                    f"{INFO} no tests matched fixture selector(s): {selector_list}"
+                                )
 
                     if should_expand_suites and collected_paths:
                         collected_paths = _expand_suites(collected_paths)
@@ -7087,6 +7122,7 @@ def execute(
     jobs_overridden: bool = False,
     all_projects: bool = False,
     match_patterns: Sequence[str] = (),
+    fixture_names: Sequence[str] = (),
     fixture_tags: Sequence[str] = (),
     no_hooks: bool = False,
 ) -> ExecutionResult:
@@ -7106,9 +7142,12 @@ def execute(
             any pattern are selected.  When path arguments are also provided
             via *tests*, only tests matching both are run (intersection).
             Empty or whitespace-only patterns are silently ignored.
-        fixture_tags: Fixture tags selected by ``-F/--fixture-tag``. Tests
-            matching any tag are selected. Intersects with TEST paths and
-            *match_patterns*.
+        fixture_names: Fixture names selected by ``--fixture-name``. Tests
+            requesting any selected fixture name are selected. Intersects with
+            TEST paths and *match_patterns*.
+        fixture_tags: Fixture tags selected by ``--fixture-tag``. Tests
+            matching any tag are selected. Combined with *fixture_names* using
+            OR semantics, then intersected with TEST paths and *match_patterns*.
     """
     resolved_jobs = jobs if jobs is not None else get_default_jobs()
     return run_cli(
@@ -7133,6 +7172,7 @@ def execute(
         jobs_overridden=jobs_overridden,
         all_projects=all_projects,
         match_patterns=match_patterns,
+        fixture_names=fixture_names,
         fixture_tags=fixture_tags,
         no_hooks=no_hooks,
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -302,6 +302,7 @@ def test_cli_match_flag(monkeypatch: pytest.MonkeyPatch) -> None:
 
     assert cli.main(["-m", "*context*"]) == 0
     assert captured["match_patterns"] == ["*context*"]
+    assert captured["fixture_names"] == []
     assert captured["fixture_tags"] == []
 
 
@@ -334,6 +335,19 @@ def test_cli_match_with_path_args(monkeypatch: pytest.MonkeyPatch) -> None:
     assert captured["tests"] == [Path("tests/foo.tql")]
 
 
+def test_cli_fixture_name_flag(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_run_cli(**kwargs: object) -> run.ExecutionResult:
+        captured.update(kwargs)
+        return _make_result()
+
+    monkeypatch.setattr(cli.runtime, "run_cli", fake_run_cli)
+
+    assert cli.main(["--fixture-name", "node", "--fixture-name", "sink"]) == 0
+    assert captured["fixture_names"] == ["node", "sink"]
+
+
 def test_cli_fixture_tag_flag(monkeypatch: pytest.MonkeyPatch) -> None:
     captured: dict[str, object] = {}
 
@@ -343,8 +357,16 @@ def test_cli_fixture_tag_flag(monkeypatch: pytest.MonkeyPatch) -> None:
 
     monkeypatch.setattr(cli.runtime, "run_cli", fake_run_cli)
 
-    assert cli.main(["-F", "container", "--fixture-tag", "docker-compose"]) == 0
+    assert cli.main(["--fixture-tag", "container", "--fixture-tag", "docker-compose"]) == 0
     assert captured["fixture_tags"] == ["container", "docker-compose"]
+
+
+def test_cli_fixture_tag_short_alias_removed(capsys: pytest.CaptureFixture[str]) -> None:
+    exit_code = cli.main(["-F", "container"])
+    assert exit_code == 2
+    captured = capsys.readouterr()
+    assert "No such option: -F" in captured.err
+    assert "Traceback" not in captured.err
 
 
 def test_cli_unknown_option(capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -8,7 +8,7 @@ import threading
 import time
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Iterable, Sequence, cast
+from typing import Iterable, cast
 
 import pytest
 
@@ -155,6 +155,7 @@ def test_execute_delegates_to_run_cli(monkeypatch: pytest.MonkeyPatch) -> None:
     assert captured["update"] is True
     assert captured["run_skipped"] is False
     assert captured["run_skipped_reasons"] == ()
+    assert captured["fixture_names"] == ()
     assert captured["fixture_tags"] == ()
 
 
@@ -4796,7 +4797,7 @@ class TestFilterPathsByPatterns:
         assert result == {foo}
 
 
-class TestFilterPathsByFixtureTags:
+class TestFilterPathsByFixtureSelector:
     def test_matches_any_fixture_tag(self, tmp_path: Path) -> None:
         root = tmp_path / "project"
         tests_dir = root / "tests"
@@ -4816,9 +4817,9 @@ class TestFilterPathsByFixtureTags:
         fixture_api._FIXTURE_TAGS["tagged"] = frozenset({"container"})  # type: ignore[attr-defined]
         fixture_api._FIXTURE_TAGS["other"] = frozenset({"node"})  # type: ignore[attr-defined]
         try:
-            result = run._filter_paths_by_fixture_tags(
+            result = run._filter_paths_by_fixture_selector(
                 {tagged, other},
-                ["container"],
+                run.FixtureSelector.from_cli(tags=["container"]),
                 coverage=False,
             )
         finally:
@@ -4833,13 +4834,50 @@ class TestFilterPathsByFixtureTags:
 
         assert result == {tagged}
 
-    def test_empty_tags_return_original_paths(self, tmp_path: Path) -> None:
+    def test_matches_any_fixture_name(self, tmp_path: Path) -> None:
+        tests_dir = tmp_path / "tests"
+        node_dir = tests_dir / "node"
+        sink_dir = tests_dir / "sink"
+        node_dir.mkdir(parents=True)
+        sink_dir.mkdir(parents=True)
+        node_test = node_dir / "case.tql"
+        sink_test = sink_dir / "case.tql"
+        node_test.touch()
+        sink_test.touch()
+        (node_dir / "test.yaml").write_text(
+            "fixtures:\n  - node:\n      tls: true\n",
+            encoding="utf-8",
+        )
+        (sink_dir / "test.yaml").write_text("fixtures: [sink]\n", encoding="utf-8")
+
+        result = run._filter_paths_by_fixture_selector(
+            {node_test, sink_test},
+            run.FixtureSelector.from_cli(names=["node"]),
+            coverage=False,
+        )
+
+        assert result == {node_test}
+
+    def test_fixture_name_matching_is_case_sensitive(self, tmp_path: Path) -> None:
+        test_path = tmp_path / "case.tql"
+        test_path.write_text("---\nfixtures: [Node]\n---\nversion\n", encoding="utf-8")
+
+        assert (
+            run._filter_paths_by_fixture_selector(
+                {test_path},
+                run.FixtureSelector.from_cli(names=["node"]),
+                coverage=False,
+            )
+            == set()
+        )
+
+    def test_empty_selectors_return_original_paths(self, tmp_path: Path) -> None:
         test_path = tmp_path / "case.tql"
         test_path.touch()
 
-        assert run._filter_paths_by_fixture_tags(
+        assert run._filter_paths_by_fixture_selector(
             {test_path},
-            ["", "  "],
+            run.FixtureSelector.from_cli(names=["", "  "], tags=["", "  "]),
             coverage=False,
         ) == {test_path}
 
@@ -4847,9 +4885,9 @@ class TestFilterPathsByFixtureTags:
         test_path = tmp_path / "case.tql"
         test_path.write_text("---\nfixtures:\n  - broken: []\n---\nversion\n", encoding="utf-8")
 
-        assert run._filter_paths_by_fixture_tags(
+        assert run._filter_paths_by_fixture_selector(
             {test_path},
-            ["container"],
+            run.FixtureSelector.from_cli(names=["node"]),
             coverage=False,
         ) == {test_path}
 
@@ -4857,9 +4895,60 @@ class TestFilterPathsByFixtureTags:
         test_path = tmp_path / "case.tql"
         test_path.write_text("---\nfixtures: [broken\n---\nversion\n", encoding="utf-8")
 
-        assert run._filter_paths_by_fixture_tags(
+        assert run._filter_paths_by_fixture_selector(
             {test_path},
-            ["container"],
+            run.FixtureSelector.from_cli(names=["node"]),
+            coverage=False,
+        ) == {test_path}
+
+    def test_name_and_tag_selectors_or_together(self, tmp_path: Path) -> None:
+        tests_dir = tmp_path / "tests"
+        node_dir = tests_dir / "node"
+        tagged_dir = tests_dir / "tagged"
+        other_dir = tests_dir / "other"
+        for directory in (node_dir, tagged_dir, other_dir):
+            directory.mkdir(parents=True)
+        node_test = node_dir / "case.tql"
+        tagged_test = tagged_dir / "case.tql"
+        other_test = other_dir / "case.tql"
+        for test_path in (node_test, tagged_test, other_test):
+            test_path.touch()
+        (node_dir / "test.yaml").write_text("fixtures: [node]\n", encoding="utf-8")
+        (tagged_dir / "test.yaml").write_text("fixtures: [tagged]\n", encoding="utf-8")
+        (other_dir / "test.yaml").write_text("fixtures: [other]\n", encoding="utf-8")
+
+        previous_tagged = fixture_api._FIXTURE_TAGS.get("tagged")  # type: ignore[attr-defined]
+        previous_other = fixture_api._FIXTURE_TAGS.get("other")  # type: ignore[attr-defined]
+        fixture_api._FIXTURE_TAGS["tagged"] = frozenset({"container"})  # type: ignore[attr-defined]
+        fixture_api._FIXTURE_TAGS["other"] = frozenset({"local"})  # type: ignore[attr-defined]
+        try:
+            result = run._filter_paths_by_fixture_selector(
+                {node_test, tagged_test, other_test},
+                run.FixtureSelector.from_cli(names=["node"], tags=["container"]),
+                coverage=False,
+            )
+        finally:
+            if previous_tagged is None:
+                fixture_api._FIXTURE_TAGS.pop("tagged", None)  # type: ignore[attr-defined]
+            else:
+                fixture_api._FIXTURE_TAGS["tagged"] = previous_tagged  # type: ignore[attr-defined]
+            if previous_other is None:
+                fixture_api._FIXTURE_TAGS.pop("other", None)  # type: ignore[attr-defined]
+            else:
+                fixture_api._FIXTURE_TAGS["other"] = previous_other  # type: ignore[attr-defined]
+
+        assert result == {node_test, tagged_test}
+
+    def test_name_matching_uses_fixture_name_not_options(self, tmp_path: Path) -> None:
+        test_path = tmp_path / "case.tql"
+        test_path.write_text(
+            "---\nfixtures:\n  - node:\n      tls: true\n  - sink\n---\nversion\n",
+            encoding="utf-8",
+        )
+
+        assert run._filter_paths_by_fixture_selector(
+            {test_path},
+            run.FixtureSelector.from_cli(names=["node"]),
             coverage=False,
         ) == {test_path}
 
@@ -5023,6 +5112,7 @@ def _run_cli_kwargs(
     tests: list[Path] | None = None,
     match_patterns: tuple[str, ...] = (),
     all_projects: bool = False,
+    fixture_names: tuple[str, ...] = (),
     fixture_tags: tuple[str, ...] = (),
 ) -> dict:
     """Return the full set of keyword arguments for ``run.run_cli``."""
@@ -5047,6 +5137,7 @@ def _run_cli_kwargs(
         jobs_overridden=False,
         all_projects=all_projects,
         match_patterns=match_patterns,
+        fixture_names=fixture_names,
         fixture_tags=fixture_tags,
     )
 
@@ -5165,6 +5256,120 @@ class TestMatchPatternIntegration:
                 fixture_api._FIXTURE_TAGS["local"] = previous_local  # type: ignore[attr-defined]
             self._teardown(info)
 
+    def test_fixture_name_filters_discovered_tests(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        info = self._setup_project(tmp_path)
+        ctx_dir = info["root"] / "tests" / "ctx"
+        other_dir = info["root"] / "tests" / "other"
+        (ctx_dir / "test.yaml").write_text(
+            "fixtures:\n  - node:\n      tls: true\n",
+            encoding="utf-8",
+        )
+        (other_dir / "test.yaml").write_text("fixtures: [sink]\n", encoding="utf-8")
+        try:
+            run._clear_directory_config_cache()
+            result = run.run_cli(
+                **_run_cli_kwargs(
+                    info["root"],
+                    fixture_names=("node",),
+                )
+            )
+            assert result.queue_size == 2
+            assert result.summary.total == 2
+        finally:
+            self._teardown(info)
+
+    def test_fixture_name_intersects_with_path_args(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        info = self._setup_project(tmp_path)
+        ctx_dir = info["root"] / "tests" / "ctx"
+        other_dir = info["root"] / "tests" / "other"
+        (ctx_dir / "test.yaml").write_text("fixtures: [node]\n", encoding="utf-8")
+        (other_dir / "test.yaml").write_text("fixtures: [node]\n", encoding="utf-8")
+        try:
+            run._clear_directory_config_cache()
+            result = run.run_cli(
+                **_run_cli_kwargs(
+                    info["root"],
+                    tests=[other_dir],
+                    fixture_names=("node",),
+                )
+            )
+            assert result.queue_size == 1
+            assert result.summary.total == 1
+        finally:
+            self._teardown(info)
+
+    def test_fixture_name_intersects_with_match_patterns(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        info = self._setup_project(tmp_path)
+        ctx_dir = info["root"] / "tests" / "ctx"
+        other_dir = info["root"] / "tests" / "other"
+        (ctx_dir / "test.yaml").write_text("fixtures: [node]\n", encoding="utf-8")
+        (other_dir / "test.yaml").write_text("fixtures: [node]\n", encoding="utf-8")
+        try:
+            run._clear_directory_config_cache()
+            result = run.run_cli(
+                **_run_cli_kwargs(
+                    info["root"],
+                    match_patterns=("delete",),
+                    fixture_names=("node",),
+                )
+            )
+            assert result.queue_size == 1
+            assert result.summary.total == 1
+        finally:
+            self._teardown(info)
+
+    def test_fixture_name_filter_happens_before_suite_expansion(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        info = self._setup_project(tmp_path)
+        suite_dir = info["root"] / "tests" / "suite"
+        suite_dir.mkdir()
+        (suite_dir / "test.yaml").write_text(
+            "suite: mixed\nfixtures: [node]\n",
+            encoding="utf-8",
+        )
+        create_test = suite_dir / "01-create.tql"
+        delete_test = suite_dir / "02-delete.tql"
+        create_test.write_text("version\n", encoding="utf-8")
+        delete_test.write_text("version\n", encoding="utf-8")
+        try:
+            run._clear_directory_config_cache()
+            result = run.run_cli(
+                **_run_cli_kwargs(
+                    info["root"],
+                    tests=[suite_dir],
+                    match_patterns=("create",),
+                    fixture_names=("node",),
+                )
+            )
+            assert result.queue_size == 2
+            assert result.summary.total == 2
+        finally:
+            self._teardown(info)
+
+    def test_fixture_name_no_match_uses_generic_selector_message(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        info = self._setup_project(tmp_path)
+        try:
+            result = run.run_cli(
+                **_run_cli_kwargs(
+                    info["root"],
+                    fixture_names=("missing",),
+                )
+            )
+            assert result.queue_size == 0
+            output = capsys.readouterr().out
+            assert "no tests matched fixture selector(s): name='missing'" in output
+        finally:
+            self._teardown(info)
+
     def test_match_and_fixture_tag_filter_before_suite_expansion(
         self,
         tmp_path: Path,
@@ -5180,19 +5385,19 @@ class TestMatchPatternIntegration:
         create_test.write_text("version\n", encoding="utf-8")
         delete_test.write_text("version\n", encoding="utf-8")
 
-        def filter_fixture_tags(
+        def filter_fixture_selector(
             paths: Iterable[Path],
-            tags: Sequence[str],
+            selector: run.FixtureSelector,
             *,
             coverage: bool,
         ) -> set[Path]:
-            del tags, coverage
+            del selector, coverage
             resolved = {path.resolve() for path in paths}
             if delete_test.resolve() in resolved:
                 return {delete_test.resolve()}
             return set()
 
-        monkeypatch.setattr(run, "_filter_paths_by_fixture_tags", filter_fixture_tags)
+        monkeypatch.setattr(run, "_filter_paths_by_fixture_selector", filter_fixture_selector)
         try:
             run._clear_directory_config_cache()
             result = run.run_cli(
@@ -5205,7 +5410,7 @@ class TestMatchPatternIntegration:
             )
             assert result.queue_size == 0
             output = capsys.readouterr().out
-            assert "no tests matched fixture tag(s)" in output
+            assert "no tests matched fixture selector(s)" in output
             assert "within the selected paths" in output
         finally:
             self._teardown(info)


### PR DESCRIPTION
## 🔍 Problem

- Operators can select tests by fixture tags, but common fixture-name selection requires adding metadata tags.
- The `-F` fixture-tag alias becomes ambiguous once fixture names and tags are both selectors.

## 🛠️ Solution

- Add repeatable `--fixture-name` selection and expose it through the runtime API.
- Combine fixture-name and fixture-tag selectors with OR semantics before intersecting with paths and `--match`.
- Remove the `-F` alias, refresh help text, changelog, and focused coverage.

## 💬 Review

- Check the selector semantics around suite expansion and config parse errors.
- Confirm that removing `-F` is acceptable before this CLI shape settles.

<sub>
📚 Docs PR: tenzir/docs#312
</sub>
