### PR TITLE
Add inline dependencies for project fixtures

### DIFF
--- a/changelog/unreleased/inline-dependencies-for-project-fixtures.md
+++ b/changelog/unreleased/inline-dependencies-for-project-fixtures.md
@@ -1,0 +1,21 @@
+---
+title: Inline dependencies for project fixtures
+type: feature
+authors:
+  - mavam
+  - codex
+created: 2026-05-13T09:10:22.248071Z
+---
+
+Project fixtures can now declare Python package dependencies inline with PEP
+723 metadata:
+
+```python
+# /// script
+# dependencies = ["boto3"]
+# ///
+```
+
+`tenzir-test` installs these dependencies with `uv` before importing fixture
+modules, so fixtures used during regular test runs and `tenzir-test --fixture`
+can manage their own Python package requirements.

--- a/changelog/unreleased/inline-dependencies-for-project-fixtures.md
+++ b/changelog/unreleased/inline-dependencies-for-project-fixtures.md
@@ -1,9 +1,10 @@
 ---
-title: Inline dependencies for project fixtures
-type: feature
+title: Project fixture inline dependencies
+type: bugfix
 authors:
   - mavam
   - codex
+pr: 47
 created: 2026-05-13T09:10:22.248071Z
 ---
 

--- a/example-project/fixtures/README.md
+++ b/example-project/fixtures/README.md
@@ -10,6 +10,30 @@ Importing the package brings the concrete modules into scope so their
 `@fixture()` decorators run. Tests that need manual control just import the
 package (for example `import fixtures`) before acquiring controllers.
 
+## Inline dependencies
+
+Fixture modules can declare Python package dependencies with PEP 723 script
+metadata. Put the metadata block at the top of the fixture file:
+
+```python
+# /// script
+# dependencies = ["boto3"]
+# ///
+
+from tenzir_test import fixture
+```
+
+When fixture modules declare dependencies, `tenzir-test` installs them into the
+active Python environment before it imports the fixtures:
+
+```sh
+uv pip install --python <current-python> boto3
+```
+
+This requires `uv` on `PATH`. Dependency metadata is supported in `fixtures.py`
+and in any Python file under the `fixtures/` package, including nested modules
+that `fixtures/__init__.py` imports.
+
 ## `http.py`
 
 The `http` fixture starts a lightweight echo server:

--- a/src/tenzir_test/inline_dependencies.py
+++ b/src/tenzir_test/inline_dependencies.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import shutil
+import sys
+import threading
+import tomllib
+from pathlib import Path
+from typing import Final
+
+
+_DEPENDENCY_INSTALL_LOCK: Final = threading.RLock()
+_INSTALLED_INLINE_DEPENDENCIES: set[tuple[str, str]] = set()
+
+
+def extract_inline_dependencies(path: Path) -> tuple[str, ...]:
+    """Extract inline PEP 723 dependencies from a Python script."""
+
+    raw = path.read_text(encoding="utf-8")
+    lines = raw.splitlines()
+
+    start = None
+    for index, line in enumerate(lines):
+        if line.strip() == "# /// script":
+            start = index + 1
+            break
+    if start is None:
+        return tuple()
+
+    end = None
+    for index in range(start, len(lines)):
+        if lines[index].strip() == "# ///":
+            end = index
+            break
+    if end is None:
+        raise RuntimeError(f"invalid script metadata in {path}: missing closing '# ///' marker")
+
+    metadata_lines: list[str] = []
+    for line in lines[start:end]:
+        stripped = line.lstrip()
+        if not stripped.startswith("#"):
+            raise RuntimeError(
+                f"invalid script metadata in {path}: each metadata line must start with '#'"
+            )
+        payload = stripped[1:]
+        if payload.startswith(" "):
+            payload = payload[1:]
+        metadata_lines.append(payload)
+
+    metadata_toml = "\n".join(metadata_lines)
+    try:
+        metadata = tomllib.loads(metadata_toml) if metadata_toml.strip() else {}
+    except tomllib.TOMLDecodeError as exc:
+        raise RuntimeError(f"invalid script metadata in {path}: {exc}") from exc
+
+    raw_dependencies = metadata.get("dependencies")
+    if raw_dependencies is None:
+        return tuple()
+    if not isinstance(raw_dependencies, list) or not all(
+        isinstance(dep, str) for dep in raw_dependencies
+    ):
+        raise RuntimeError(
+            f"invalid script metadata in {path}: 'dependencies' must be a list of strings"
+        )
+
+    deduplicated: list[str] = []
+    seen: set[str] = set()
+    for dep in raw_dependencies:
+        normalized = dep.strip()
+        if not normalized or normalized in seen:
+            continue
+        seen.add(normalized)
+        deduplicated.append(normalized)
+    return tuple(deduplicated)
+
+
+def install_inline_dependencies(
+    owner: Path,
+    dependencies: tuple[str, ...],
+    *,
+    timeout: int,
+    context: str,
+) -> None:
+    if not dependencies:
+        return
+
+    uv_binary = shutil.which("uv")
+    if uv_binary is None:
+        raise RuntimeError(
+            f"{context} in {owner} declare dependencies {dependencies!r}, "
+            "but 'uv' is not available on PATH"
+        )
+
+    from . import run as run_mod
+
+    with _DEPENDENCY_INSTALL_LOCK:
+        missing_dependencies = [
+            dep
+            for dep in dependencies
+            if (sys.executable, dep) not in _INSTALLED_INLINE_DEPENDENCIES
+        ]
+        if not missing_dependencies:
+            return
+        run_mod.run_subprocess(
+            [
+                uv_binary,
+                "pip",
+                "install",
+                "--python",
+                sys.executable,
+                *missing_dependencies,
+            ],
+            timeout=max(timeout, 60),
+            capture_output=not run_mod.is_passthrough_enabled(),
+            check=True,
+        )
+        for dep in missing_dependencies:
+            _INSTALLED_INLINE_DEPENDENCIES.add((sys.executable, dep))

--- a/src/tenzir_test/run.py
+++ b/src/tenzir_test/run.py
@@ -3063,14 +3063,17 @@ def _format_missing_fixture_dependency_error(
 
 
 def _fixture_dependency_files(root: Path) -> tuple[Path, ...]:
-    fixtures_file = root / "fixtures.py"
     fixtures_package = root / "fixtures"
-    candidates: list[Path] = []
-    if fixtures_file.exists():
-        candidates.append(fixtures_file)
+    fixtures_file = root / "fixtures.py"
+
     if fixtures_package.is_dir():
-        candidates.extend(sorted(fixtures_package.glob("**/*.py")))
-    return tuple(candidates)
+        init_file = fixtures_package / "__init__.py"
+        if init_file.exists():
+            return tuple(sorted(fixtures_package.glob("**/*.py")))
+        return tuple(sorted(fixtures_package.glob("*.py")))
+    if fixtures_file.exists():
+        return (fixtures_file,)
+    return tuple()
 
 
 def _collect_fixture_dependencies(root: Path) -> tuple[str, ...]:

--- a/src/tenzir_test/run.py
+++ b/src/tenzir_test/run.py
@@ -36,6 +36,7 @@ import tenzir_test.fixtures as fixtures_impl
 from . import hooks as hooks_impl
 from . import packages
 from .config import Settings, discover_settings
+from .inline_dependencies import extract_inline_dependencies, install_inline_dependencies
 from .runners import (
     ShellRunner,  # noqa: F401
     CustomPythonFixture,  # noqa: F401
@@ -3061,6 +3062,29 @@ def _format_missing_fixture_dependency_error(
     )
 
 
+def _fixture_dependency_files(root: Path) -> tuple[Path, ...]:
+    fixtures_file = root / "fixtures.py"
+    fixtures_package = root / "fixtures"
+    candidates: list[Path] = []
+    if fixtures_file.exists():
+        candidates.append(fixtures_file)
+    if fixtures_package.is_dir():
+        candidates.extend(sorted(fixtures_package.glob("**/*.py")))
+    return tuple(candidates)
+
+
+def _collect_fixture_dependencies(root: Path) -> tuple[str, ...]:
+    dependencies: list[str] = []
+    seen: set[str] = set()
+    for fixture_file in _fixture_dependency_files(root):
+        for dependency in extract_inline_dependencies(fixture_file):
+            if dependency in seen:
+                continue
+            seen.add(dependency)
+            dependencies.append(dependency)
+    return tuple(dependencies)
+
+
 def _load_project_fixtures(root: Path, *, expose_namespace: bool) -> None:
     resolved_root = root.resolve()
     if resolved_root in _FIXTURE_LOAD_ROOTS:
@@ -3084,6 +3108,14 @@ def _load_project_fixtures(root: Path, *, expose_namespace: bool) -> None:
             ) from exc
 
     try:
+        fixture_dependencies = _collect_fixture_dependencies(root)
+        install_inline_dependencies(
+            root,
+            fixture_dependencies,
+            timeout=300,
+            context="project fixtures",
+        )
+
         alias_target = None
         if fixtures_package.is_dir():
             init_file = fixtures_package / "__init__.py"

--- a/src/tenzir_test/runners/custom_python_fixture_runner.py
+++ b/src/tenzir_test/runners/custom_python_fixture_runner.py
@@ -4,23 +4,20 @@ import dataclasses
 import enum
 import json
 import os
-import shutil
 import shlex
 import subprocess
 import sys
-import threading
-import tomllib
 import typing
 from pathlib import Path
 
 from tenzir_test import fixtures as fixture_api
+from tenzir_test.inline_dependencies import (
+    extract_inline_dependencies,
+    install_inline_dependencies,
+)
 
 from ._utils import get_run_module, resolve_run_module_dir
 from .ext_runner import ExtRunner
-
-
-_DEPENDENCY_INSTALL_LOCK = threading.RLock()
-_INSTALLED_SCRIPT_DEPENDENCIES: set[str] = set()
 
 
 def _jsonify_config(config: dict[str, typing.Any]) -> dict[str, typing.Any]:
@@ -41,116 +38,6 @@ def _jsonify_config(config: dict[str, typing.Any]) -> dict[str, typing.Any]:
         return value
 
     return {str(key): _convert(val) for key, val in config.items()}
-
-
-def _extract_script_dependencies(test: Path) -> tuple[str, ...]:
-    """Extract inline PEP 723 dependencies from a Python test script.
-
-    The runner recognizes a metadata block of the form:
-
-        # /// script
-        # dependencies = ["pkg", "other>=1.0"]
-        # ///
-    """
-
-    raw = test.read_text(encoding="utf-8")
-    lines = raw.splitlines()
-
-    start = None
-    for index, line in enumerate(lines):
-        if line.strip() == "# /// script":
-            start = index + 1
-            break
-    if start is None:
-        return tuple()
-
-    end = None
-    for index in range(start, len(lines)):
-        if lines[index].strip() == "# ///":
-            end = index
-            break
-    if end is None:
-        raise RuntimeError(f"invalid script metadata in {test}: missing closing '# ///' marker")
-
-    metadata_lines: list[str] = []
-    for line in lines[start:end]:
-        stripped = line.lstrip()
-        if not stripped.startswith("#"):
-            raise RuntimeError(
-                f"invalid script metadata in {test}: each metadata line must start with '#'"
-            )
-        payload = stripped[1:]
-        if payload.startswith(" "):
-            payload = payload[1:]
-        metadata_lines.append(payload)
-
-    metadata_toml = "\n".join(metadata_lines)
-    try:
-        metadata = tomllib.loads(metadata_toml) if metadata_toml.strip() else {}
-    except tomllib.TOMLDecodeError as exc:
-        raise RuntimeError(f"invalid script metadata in {test}: {exc}") from exc
-
-    raw_dependencies = metadata.get("dependencies")
-    if raw_dependencies is None:
-        return tuple()
-    if not isinstance(raw_dependencies, list) or not all(
-        isinstance(dep, str) for dep in raw_dependencies
-    ):
-        raise RuntimeError(
-            f"invalid script metadata in {test}: 'dependencies' must be a list of strings"
-        )
-
-    deduplicated: list[str] = []
-    seen: set[str] = set()
-    for dep in raw_dependencies:
-        normalized = dep.strip()
-        if not normalized or normalized in seen:
-            continue
-        seen.add(normalized)
-        deduplicated.append(normalized)
-    return tuple(deduplicated)
-
-
-def _install_script_dependencies(
-    test: Path,
-    dependencies: tuple[str, ...],
-    *,
-    timeout: int,
-    run_mod: typing.Any,
-) -> None:
-    if not dependencies:
-        return
-    uv_binary = shutil.which("uv")
-    if uv_binary is None:
-        raise RuntimeError(
-            f"python test {test} declares dependencies {dependencies!r}, "
-            "but 'uv' is not available on PATH"
-        )
-
-    environment_key_prefix = f"{sys.executable}:"
-    with _DEPENDENCY_INSTALL_LOCK:
-        missing_dependencies = [
-            dep
-            for dep in dependencies
-            if f"{environment_key_prefix}{dep}" not in _INSTALLED_SCRIPT_DEPENDENCIES
-        ]
-        if not missing_dependencies:
-            return
-        run_mod.run_subprocess(
-            [
-                uv_binary,
-                "pip",
-                "install",
-                "--python",
-                sys.executable,
-                *missing_dependencies,
-            ],
-            timeout=max(timeout, 60),
-            capture_output=not run_mod.is_passthrough_enabled(),
-            check=True,
-        )
-        for dep in missing_dependencies:
-            _INSTALLED_SCRIPT_DEPENDENCIES.add(f"{environment_key_prefix}{dep}")
 
 
 class CustomPythonFixture(ExtRunner):
@@ -184,12 +71,12 @@ class CustomPythonFixture(ExtRunner):
             )
             node_requested = any(spec.name == "node" for spec in fixtures)
             timeout = typing.cast(int, test_config["timeout"])
-            script_dependencies = _extract_script_dependencies(test)
-            _install_script_dependencies(
+            script_dependencies = extract_inline_dependencies(test)
+            install_inline_dependencies(
                 test,
                 script_dependencies,
                 timeout=timeout,
-                run_mod=run_mod,
+                context="python test",
             )
             fixture_context = fixture_api.FixtureContext(
                 test=test,

--- a/tests/test_python_runner.py
+++ b/tests/test_python_runner.py
@@ -14,6 +14,7 @@ import signal
 
 from tenzir_test import _python_runner as python_runner
 from tenzir_test import config, run, fixtures
+from tenzir_test import inline_dependencies
 from tenzir_test.runners import custom_python_fixture_runner as python_runner_impl
 from tenzir_test.runners.custom_python_fixture_runner import _jsonify_config
 
@@ -103,7 +104,7 @@ def test_extract_script_dependencies(tmp_path: Path) -> None:
         encoding="utf-8",
     )
 
-    dependencies = python_runner_impl._extract_script_dependencies(script)
+    dependencies = inline_dependencies.extract_inline_dependencies(script)
     assert dependencies == ("pymysql", "certifi>=2025.0")
 
 
@@ -150,7 +151,7 @@ def test_python_runner_installs_inline_dependencies(
 
     monkeypatch.setattr(run.subprocess, "run", fake_run)
     monkeypatch.setattr(shutil, "which", lambda name: "uv" if name == "uv" else None)
-    python_runner_impl._INSTALLED_SCRIPT_DEPENDENCIES.clear()
+    inline_dependencies._INSTALLED_INLINE_DEPENDENCIES.clear()  # type: ignore[attr-defined]
 
     runner = run.CustomPythonFixture()
     assert runner.run(script, update=True, coverage=False)

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -18,6 +18,15 @@ from tenzir_test.fixtures import node as node_fixture
 from tenzir_test.runners.runner import Runner
 
 
+def _clear_loaded_fixture_modules() -> None:
+    run._FIXTURE_LOAD_ROOTS.clear()  # type: ignore[attr-defined]
+    sys.modules.pop("fixtures", None)
+    sys.modules.pop("_tenzir_project_fixtures", None)
+    for module_name in list(sys.modules):
+        if module_name.startswith(("_tenzir_project_fixture_", "_tenzir_project_fixtures.")):
+            sys.modules.pop(module_name, None)
+
+
 def test_main_warns_when_outside_project_root(tmp_path, monkeypatch, capsys):
     original_settings = run._settings
     original_root = run.ROOT
@@ -168,22 +177,138 @@ def test_load_project_fixtures_reports_missing_python_dependency(tmp_path: Path)
     )
 
     try:
-        run._FIXTURE_LOAD_ROOTS.clear()  # type: ignore[attr-defined]
+        _clear_loaded_fixture_modules()
         with pytest.raises(RuntimeError, match="missing Python dependency") as exc_info:
             run._load_project_fixtures(tmp_path, expose_namespace=False)  # type: ignore[attr-defined]
     finally:
-        run._FIXTURE_LOAD_ROOTS.clear()  # type: ignore[attr-defined]
-        sys.modules.pop("fixtures", None)
-        sys.modules.pop("_tenzir_project_fixtures", None)
-        for module_name in list(sys.modules):
-            if module_name.startswith("_tenzir_project_fixture_"):
-                sys.modules.pop(module_name, None)
+        _clear_loaded_fixture_modules()
 
     message = str(exc_info.value)
     assert "totally_missing_fixture_dependency" in message
     assert "fixtures/__init__.py" in message
     assert "uv run tenzir-test" in message
     assert "uvx --with <package> tenzir-test" in message
+
+
+def test_load_project_fixtures_installs_inline_dependencies_before_import(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fixture_dir = tmp_path / "fixtures"
+    fixture_dir.mkdir()
+    install_marker = tmp_path / "installed"
+    (fixture_dir / "__init__.py").write_text(
+        "from .localstack import localstack\n",
+        encoding="utf-8",
+    )
+    (fixture_dir / "localstack.py").write_text(
+        "\n".join(
+            [
+                "# /// script",
+                '# dependencies = ["demo-fixture-dep"]',
+                "# ///",
+                f"assert __import__('pathlib').Path({str(install_marker)!r}).exists()",
+                "from tenzir_test import fixture",
+                "",
+                '@fixture(name="demo-inline-dependency", replace=True)',
+                "def localstack():",
+                "    yield {}",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    calls: list[tuple[Path, tuple[str, ...], str]] = []
+
+    def fake_install(
+        owner: Path,
+        dependencies: tuple[str, ...],
+        *,
+        timeout: int,
+        context: str,
+    ) -> None:
+        assert timeout == 300
+        install_marker.touch()
+        calls.append((owner, dependencies, context))
+
+    monkeypatch.setattr(run, "install_inline_dependencies", fake_install)
+
+    try:
+        _clear_loaded_fixture_modules()
+        run._load_project_fixtures(tmp_path, expose_namespace=False)  # type: ignore[attr-defined]
+        assert "demo-inline-dependency" in fixture_api._FACTORIES  # type: ignore[attr-defined]
+    finally:
+        _clear_loaded_fixture_modules()
+        fixture_api._FACTORIES.pop("demo-inline-dependency", None)  # type: ignore[attr-defined]
+
+    assert calls == [(tmp_path, ("demo-fixture-dep",), "project fixtures")]
+
+
+def test_fixture_dependencies_scan_recursively(tmp_path: Path) -> None:
+    nested_dir = tmp_path / "fixtures" / "nested"
+    nested_dir.mkdir(parents=True)
+    (nested_dir / "tool.py").write_text(
+        "\n".join(
+            [
+                "# /// script",
+                '# dependencies = ["demo-nested-dep"]',
+                "# ///",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    assert run._collect_fixture_dependencies(tmp_path) == ("demo-nested-dep",)  # type: ignore[attr-defined]
+
+
+def test_load_project_fixtures_without_inline_dependencies_does_not_call_uv(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fixture_dir = tmp_path / "fixtures"
+    fixture_dir.mkdir()
+    (fixture_dir / "__init__.py").write_text(
+        "from tenzir_test import fixture\n"
+        '@fixture(name="plain-fixture", replace=True)\n'
+        "def run():\n"
+        "    yield {}\n",
+        encoding="utf-8",
+    )
+
+    def fail_run_subprocess(*args: object, **kwargs: object) -> None:
+        pytest.fail("dependency installation should not run")
+
+    monkeypatch.setattr(run, "run_subprocess", fail_run_subprocess)
+
+    try:
+        _clear_loaded_fixture_modules()
+        run._load_project_fixtures(tmp_path, expose_namespace=False)  # type: ignore[attr-defined]
+    finally:
+        _clear_loaded_fixture_modules()
+        fixture_api._FACTORIES.pop("plain-fixture", None)  # type: ignore[attr-defined]
+
+
+def test_invalid_fixture_inline_metadata_mentions_fixture_file(tmp_path: Path) -> None:
+    fixture_dir = tmp_path / "fixtures"
+    fixture_dir.mkdir()
+    fixture_file = fixture_dir / "broken.py"
+    fixture_file.write_text(
+        "\n".join(
+            [
+                "# /// script",
+                '# dependencies = ["demo-fixture-dep"]',
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    try:
+        _clear_loaded_fixture_modules()
+        with pytest.raises(RuntimeError, match="broken.py.*missing closing '# ///' marker"):
+            run._load_project_fixtures(tmp_path, expose_namespace=False)  # type: ignore[attr-defined]
+    finally:
+        _clear_loaded_fixture_modules()
 
 
 def test_format_summary_reports_counts_and_percentages() -> None:

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -244,9 +244,32 @@ def test_load_project_fixtures_installs_inline_dependencies_before_import(
     assert calls == [(tmp_path, ("demo-fixture-dep",), "project fixtures")]
 
 
-def test_fixture_dependencies_scan_recursively(tmp_path: Path) -> None:
-    nested_dir = tmp_path / "fixtures" / "nested"
+def test_fixture_dependencies_scan_package_modules_recursively(tmp_path: Path) -> None:
+    fixture_dir = tmp_path / "fixtures"
+    nested_dir = fixture_dir / "nested"
     nested_dir.mkdir(parents=True)
+    (tmp_path / "fixtures.py").write_text(
+        "\n".join(
+            [
+                "# /// script",
+                '# dependencies = ["demo-stale-dep"]',
+                "# ///",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (fixture_dir / "__init__.py").write_text(
+        "\n".join(
+            [
+                "# /// script",
+                '# dependencies = ["demo-package-dep"]',
+                "# ///",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
     (nested_dir / "tool.py").write_text(
         "\n".join(
             [
@@ -259,7 +282,40 @@ def test_fixture_dependencies_scan_recursively(tmp_path: Path) -> None:
         encoding="utf-8",
     )
 
-    assert run._collect_fixture_dependencies(tmp_path) == ("demo-nested-dep",)  # type: ignore[attr-defined]
+    assert run._collect_fixture_dependencies(tmp_path) == (  # type: ignore[attr-defined]
+        "demo-package-dep",
+        "demo-nested-dep",
+    )
+
+
+def test_fixture_dependencies_scan_top_level_modules_only(tmp_path: Path) -> None:
+    fixture_dir = tmp_path / "fixtures"
+    nested_dir = fixture_dir / "nested"
+    nested_dir.mkdir(parents=True)
+    (fixture_dir / "tool.py").write_text(
+        "\n".join(
+            [
+                "# /// script",
+                '# dependencies = ["demo-tool-dep"]',
+                "# ///",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (nested_dir / "unused.py").write_text(
+        "\n".join(
+            [
+                "# /// script",
+                '# dependencies = ["demo-nested-dep"]',
+                "# ///",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    assert run._collect_fixture_dependencies(tmp_path) == ("demo-tool-dep",)  # type: ignore[attr-defined]
 
 
 def test_load_project_fixtures_without_inline_dependencies_does_not_call_uv(


### PR DESCRIPTION
## 🔍 Problem

- Project fixtures could import optional Python packages, but the harness only
  installed PEP 723 dependencies for Python test scripts.
- Fixture users had to remember wrapper commands such as `uvx --with ...`, and
  standalone fixture mode had the same gap.

## 🛠️ Solution

- Share inline dependency parsing and installation across Python tests and
  project fixture loading.
- Scan `fixtures.py` and recursive `fixtures/**/*.py` files before importing
  project fixtures.
- Document fixture dependency metadata and add regression coverage for install
  order, recursive scans, empty metadata, invalid metadata, and undeclared
  dependency fallbacks.

## 💬 Review

- Focus on the eager fixture dependency scan and whether installing all declared
  fixture dependencies before fixture import is the right trade-off for the
  current eager registration model.

<sub>
📚 Docs PR: tenzir/docs#317
</sub>
