### PR TITLE
Skip installed inline dependencies

### DIFF
--- a/changelog/unreleased/inline-dependency-installation-control.md
+++ b/changelog/unreleased/inline-dependency-installation-control.md
@@ -12,7 +12,8 @@ Inline Python dependencies declared by tests or fixtures no longer force a
 runtime `uv pip install` when a bare dependency name is already available in
 the active Python environment.
 
-Set `TENZIR_TEST_DISABLE_INLINE_DEPENDENCY_INSTALL=1` to skip inline dependency
+Pass `--disable-inline-dependency-install`, or set
+`TENZIR_TEST_DISABLE_INLINE_DEPENDENCY_INSTALL=1`, to skip inline dependency
 installation entirely when another tool provisions the test environment. The
 harness still reads dependency metadata, but it leaves package installation to
 the caller.

--- a/changelog/unreleased/inline-dependency-installation-control.md
+++ b/changelog/unreleased/inline-dependency-installation-control.md
@@ -1,0 +1,18 @@
+---
+title: Inline dependency installation control
+type: bugfix
+authors:
+  - tobim
+  - codex
+pr: 49
+created: 2026-05-27T00:00:00Z
+---
+
+Inline Python dependencies declared by tests or fixtures no longer force a
+runtime `uv pip install` when a bare dependency name is already available in
+the active Python environment.
+
+Set `TENZIR_TEST_DISABLE_INLINE_DEPENDENCY_INSTALL=1` to skip inline dependency
+installation entirely when another tool provisions the test environment. The
+harness still reads dependency metadata, but it leaves package installation to
+the caller.

--- a/example-project/fixtures/README.md
+++ b/example-project/fixtures/README.md
@@ -30,9 +30,15 @@ active Python environment before it imports the fixtures:
 uv pip install --python <current-python> boto3
 ```
 
-This requires `uv` on `PATH`. Dependency metadata is supported in `fixtures.py`
-and in any Python file under the `fixtures/` package, including nested modules
-that `fixtures/__init__.py` imports.
+This requires `uv` on `PATH` unless the dependency is already installed in the
+active Python environment. Set
+`TENZIR_TEST_DISABLE_INLINE_DEPENDENCY_INSTALL=1` when another tool, such as
+Nix, provisions all fixture dependencies and `tenzir-test` should never install
+them at runtime.
+
+Dependency metadata is supported in `fixtures.py` and in any Python file under
+the `fixtures/` package, including nested modules that `fixtures/__init__.py`
+imports.
 
 ## `http.py`
 

--- a/example-project/fixtures/README.md
+++ b/example-project/fixtures/README.md
@@ -31,8 +31,8 @@ uv pip install --python <current-python> boto3
 ```
 
 This requires `uv` on `PATH` unless the dependency is already installed in the
-active Python environment. Set
-`TENZIR_TEST_DISABLE_INLINE_DEPENDENCY_INSTALL=1` when another tool, such as
+active Python environment. Pass `--disable-inline-dependency-install`, or set
+`TENZIR_TEST_DISABLE_INLINE_DEPENDENCY_INSTALL=1`, when another tool, such as
 Nix, provisions all fixture dependencies and `tenzir-test` should never install
 them at runtime.
 

--- a/src/tenzir_test/cli.py
+++ b/src/tenzir_test/cli.py
@@ -2,13 +2,16 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Iterator, Sequence
+from contextlib import contextmanager
+import os
 from pathlib import Path
 import sys
 
 import click
 
 from . import __version__, run as runtime
+from .inline_dependencies import DISABLE_INLINE_DEPENDENCY_INSTALL_ENV
 
 
 class _UnindentedEpilogCommand(click.Command):
@@ -28,6 +31,23 @@ def _normalize_exit_code(value: object) -> int:
     if isinstance(value, int):
         return value
     return 1
+
+
+@contextmanager
+def _inline_dependency_install_scope(disabled: bool) -> Iterator[None]:
+    if not disabled:
+        yield
+        return
+
+    previous_value = os.environ.get(DISABLE_INLINE_DEPENDENCY_INSTALL_ENV)
+    os.environ[DISABLE_INLINE_DEPENDENCY_INSTALL_ENV] = "1"
+    try:
+        yield
+    finally:
+        if previous_value is None:
+            os.environ.pop(DISABLE_INLINE_DEPENDENCY_INSTALL_ENV, None)
+        else:
+            os.environ[DISABLE_INLINE_DEPENDENCY_INSTALL_ENV] = previous_value
 
 
 @click.command(
@@ -200,6 +220,11 @@ Documentation: https://docs.tenzir.com/reference/test-framework/
     help="Disable project hook loading and invocation.",
 )
 @click.option(
+    "--disable-inline-dependency-install",
+    is_flag=True,
+    help="Disable runtime installation for inline Python dependencies.",
+)
+@click.option(
     "-m",
     "--match",
     "match_patterns",
@@ -267,6 +292,7 @@ def cli(
     run_skipped_reasons: tuple[str, ...],
     all_projects: bool,
     no_hooks: bool,
+    disable_inline_dependency_install: bool,
     fixture_names: tuple[str, ...],
     fixture_tags: tuple[str, ...],
 ) -> int:
@@ -311,47 +337,48 @@ def cli(
     jobs_overridden = jobs_source is not click.core.ParameterSource.DEFAULT
 
     try:
-        if fixtures:
-            if tests:
-                raise click.UsageError(
-                    "positional TEST arguments cannot be used with --fixture mode"
+        with _inline_dependency_install_scope(disable_inline_dependency_install):
+            if fixtures:
+                if tests:
+                    raise click.UsageError(
+                        "positional TEST arguments cannot be used with --fixture mode"
+                    )
+                return runtime.run_fixture_mode_cli(
+                    root=root,
+                    package_dirs=package_paths,
+                    fixtures=list(fixtures),
+                    debug=debug,
+                    keep_tmp_dirs=keep_tmp_dirs,
+                    no_hooks=no_hooks,
                 )
-            return runtime.run_fixture_mode_cli(
+
+            result = runtime.run_cli(
                 root=root,
                 package_dirs=package_paths,
-                fixtures=list(fixtures),
+                tests=list(tests),
+                update=update,
                 debug=debug,
+                purge=purge,
+                coverage=coverage,
+                coverage_source_dir=coverage_source_dir,
+                runner_summary=runner_summary,
+                fixture_summary=fixture_summary,
+                show_summary=show_summary,
+                show_diff_output=show_diff_output,
+                show_diff_stat=show_diff_stat,
                 keep_tmp_dirs=keep_tmp_dirs,
+                jobs=jobs,
+                passthrough=passthrough,
+                verbose=verbose,
+                run_skipped=run_skipped,
+                run_skipped_reasons=list(run_skipped_reasons),
+                jobs_overridden=jobs_overridden,
+                all_projects=all_projects,
+                match_patterns=list(match_patterns),
+                fixture_names=list(fixture_names),
+                fixture_tags=list(fixture_tags),
                 no_hooks=no_hooks,
             )
-
-        result = runtime.run_cli(
-            root=root,
-            package_dirs=package_paths,
-            tests=list(tests),
-            update=update,
-            debug=debug,
-            purge=purge,
-            coverage=coverage,
-            coverage_source_dir=coverage_source_dir,
-            runner_summary=runner_summary,
-            fixture_summary=fixture_summary,
-            show_summary=show_summary,
-            show_diff_output=show_diff_output,
-            show_diff_stat=show_diff_stat,
-            keep_tmp_dirs=keep_tmp_dirs,
-            jobs=jobs,
-            passthrough=passthrough,
-            verbose=verbose,
-            run_skipped=run_skipped,
-            run_skipped_reasons=list(run_skipped_reasons),
-            jobs_overridden=jobs_overridden,
-            all_projects=all_projects,
-            match_patterns=list(match_patterns),
-            fixture_names=list(fixture_names),
-            fixture_tags=list(fixture_tags),
-            no_hooks=no_hooks,
-        )
     except runtime.HarnessError as exc:
         if exc.show_message and exc.args:
             raise click.ClickException(str(exc)) from exc

--- a/src/tenzir_test/inline_dependencies.py
+++ b/src/tenzir_test/inline_dependencies.py
@@ -14,7 +14,7 @@ from typing import Final
 _DEPENDENCY_INSTALL_LOCK: Final = threading.RLock()
 _INSTALLED_INLINE_DEPENDENCIES: set[tuple[str, str]] = set()
 _BARE_REQUIREMENT_RE: Final = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]*")
-_DISABLE_INSTALL_ENV: Final = "TENZIR_TEST_DISABLE_INLINE_DEPENDENCY_INSTALL"
+DISABLE_INLINE_DEPENDENCY_INSTALL_ENV: Final = "TENZIR_TEST_DISABLE_INLINE_DEPENDENCY_INSTALL"
 
 
 def extract_inline_dependencies(path: Path) -> tuple[str, ...]:
@@ -85,7 +85,7 @@ def install_inline_dependencies(
     timeout: int,
     context: str,
 ) -> None:
-    if not dependencies or os.environ.get(_DISABLE_INSTALL_ENV):
+    if not dependencies or os.environ.get(DISABLE_INLINE_DEPENDENCY_INSTALL_ENV):
         return
 
     from . import run as run_mod

--- a/src/tenzir_test/inline_dependencies.py
+++ b/src/tenzir_test/inline_dependencies.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from importlib.metadata import PackageNotFoundError, distribution
+import os
+import re
 import shutil
 import sys
 import threading
@@ -10,6 +13,8 @@ from typing import Final
 
 _DEPENDENCY_INSTALL_LOCK: Final = threading.RLock()
 _INSTALLED_INLINE_DEPENDENCIES: set[tuple[str, str]] = set()
+_BARE_REQUIREMENT_RE: Final = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]*")
+_DISABLE_INSTALL_ENV: Final = "TENZIR_TEST_DISABLE_INLINE_DEPENDENCY_INSTALL"
 
 
 def extract_inline_dependencies(path: Path) -> tuple[str, ...]:
@@ -80,15 +85,8 @@ def install_inline_dependencies(
     timeout: int,
     context: str,
 ) -> None:
-    if not dependencies:
+    if not dependencies or os.environ.get(_DISABLE_INSTALL_ENV):
         return
-
-    uv_binary = shutil.which("uv")
-    if uv_binary is None:
-        raise RuntimeError(
-            f"{context} in {owner} declare dependencies {dependencies!r}, "
-            "but 'uv' is not available on PATH"
-        )
 
     from . import run as run_mod
 
@@ -97,9 +95,17 @@ def install_inline_dependencies(
             dep
             for dep in dependencies
             if (sys.executable, dep) not in _INSTALLED_INLINE_DEPENDENCIES
+            and not _is_installed_bare_requirement(dep)
         ]
         if not missing_dependencies:
             return
+
+        uv_binary = shutil.which("uv")
+        if uv_binary is None:
+            raise RuntimeError(
+                f"{context} in {owner} declare dependencies {dependencies!r}, "
+                "but 'uv' is not available on PATH"
+            )
         run_mod.run_subprocess(
             [
                 uv_binary,
@@ -115,3 +121,13 @@ def install_inline_dependencies(
         )
         for dep in missing_dependencies:
             _INSTALLED_INLINE_DEPENDENCIES.add((sys.executable, dep))
+
+
+def _is_installed_bare_requirement(dependency: str) -> bool:
+    if _BARE_REQUIREMENT_RE.fullmatch(dependency) is None:
+        return False
+    try:
+        distribution(dependency)
+    except PackageNotFoundError:
+        return False
+    return True

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import os
+
 import pytest
 import tenzir_test
 
 from tenzir_test import cli, run
+from tenzir_test.inline_dependencies import DISABLE_INLINE_DEPENDENCY_INSTALL_ENV
 
 
 def _make_result(exit_code: int = 0, *, interrupted: bool = False) -> run.ExecutionResult:
@@ -252,6 +255,23 @@ def test_cli_no_diff_stat_flag(monkeypatch: pytest.MonkeyPatch) -> None:
     assert captured["show_diff_stat"] is False
 
 
+def test_cli_disable_inline_dependency_install_flag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_run_cli(**_: object) -> run.ExecutionResult:
+        captured["disabled"] = os.environ.get(DISABLE_INLINE_DEPENDENCY_INSTALL_ENV)
+        return _make_result()
+
+    monkeypatch.delenv(DISABLE_INLINE_DEPENDENCY_INSTALL_ENV, raising=False)
+    monkeypatch.setattr(cli.runtime, "run_cli", fake_run_cli)
+
+    assert cli.main(["--disable-inline-dependency-install"]) == 0
+    assert captured["disabled"] == "1"
+    assert DISABLE_INLINE_DEPENDENCY_INSTALL_ENV not in os.environ
+
+
 def test_cli_version_flag(capsys: pytest.CaptureFixture[str]) -> None:
     exit_code = cli.main(["--version"])
     assert exit_code == 0
@@ -281,6 +301,29 @@ def test_cli_fixture_mode_dispatch(monkeypatch: pytest.MonkeyPatch) -> None:
     from pathlib import Path
 
     assert captured["package_dirs"] == [Path("a"), Path("b")]
+
+
+def test_cli_fixture_mode_disable_inline_dependency_install(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_fixture_mode_cli(**kwargs: object) -> int:
+        captured.update(kwargs)
+        captured["disabled"] = os.environ.get(DISABLE_INLINE_DEPENDENCY_INSTALL_ENV)
+        return 7
+
+    def fake_run_cli(**_: object) -> run.ExecutionResult:
+        raise AssertionError("run_cli must not be called in --fixture mode")
+
+    monkeypatch.delenv(DISABLE_INLINE_DEPENDENCY_INSTALL_ENV, raising=False)
+    monkeypatch.setattr(cli.runtime, "run_fixture_mode_cli", fake_fixture_mode_cli)
+    monkeypatch.setattr(cli.runtime, "run_cli", fake_run_cli)
+
+    exit_code = cli.main(["--fixture", "mysql", "--disable-inline-dependency-install"])
+    assert exit_code == 7
+    assert captured["disabled"] == "1"
+    assert DISABLE_INLINE_DEPENDENCY_INSTALL_ENV not in os.environ
 
 
 def test_cli_fixture_mode_disallows_tests(capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/test_python_runner.py
+++ b/tests/test_python_runner.py
@@ -166,6 +166,71 @@ def test_python_runner_installs_inline_dependencies(
     assert uv_install_calls[0][-1] == "pymysql"
 
 
+def test_inline_dependency_install_skips_installed_bare_dependency(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def fail_run_subprocess(*args: object, **kwargs: object) -> None:
+        pytest.fail("installed dependency should not be installed")
+
+    monkeypatch.setattr(run, "run_subprocess", fail_run_subprocess)
+    monkeypatch.setattr(shutil, "which", lambda name: None)
+    monkeypatch.setattr(inline_dependencies, "distribution", lambda dependency: object())
+    inline_dependencies._INSTALLED_INLINE_DEPENDENCIES.clear()  # type: ignore[attr-defined]
+
+    inline_dependencies.install_inline_dependencies(
+        tmp_path,
+        ("boto3",),
+        timeout=30,
+        context="python test",
+    )
+
+
+def test_inline_dependency_install_can_be_disabled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def fail_run_subprocess(*args: object, **kwargs: object) -> None:
+        pytest.fail("dependency installation should be disabled")
+
+    monkeypatch.setattr(run, "run_subprocess", fail_run_subprocess)
+    monkeypatch.setattr(shutil, "which", lambda name: None)
+    monkeypatch.setenv("TENZIR_TEST_DISABLE_INLINE_DEPENDENCY_INSTALL", "1")
+    inline_dependencies._INSTALLED_INLINE_DEPENDENCIES.clear()  # type: ignore[attr-defined]
+
+    inline_dependencies.install_inline_dependencies(
+        tmp_path,
+        ("missing-package", "certifi>=2025.0"),
+        timeout=30,
+        context="python test",
+    )
+
+
+def test_inline_dependency_install_keeps_installing_versioned_requirements(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run_subprocess(args, **kwargs):  # noqa: ANN001
+        calls.append([str(part) for part in args])
+        return _DummyCompleted()
+
+    monkeypatch.setattr(run, "run_subprocess", fake_run_subprocess)
+    monkeypatch.setattr(run, "is_passthrough_enabled", lambda: False)
+    monkeypatch.setattr(shutil, "which", lambda name: "uv" if name == "uv" else None)
+    monkeypatch.setattr(inline_dependencies, "distribution", lambda dependency: object())
+    inline_dependencies._INSTALLED_INLINE_DEPENDENCIES.clear()  # type: ignore[attr-defined]
+
+    inline_dependencies.install_inline_dependencies(
+        tmp_path,
+        ("certifi>=2025.0",),
+        timeout=30,
+        context="python test",
+    )
+
+    assert len(calls) == 1
+    assert calls[0][1:3] == ["pip", "install"]
+    assert calls[0][-1] == "certifi>=2025.0"
+
+
 def test_python_runner_update_writes_reference(
     python_fixture_root: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## 🔍 Problem

- Inline dependencies for Python tests and project fixtures are always installed with `uv pip install`.
- Pre-provisioned environments, such as Nix checks, may already provide those packages through the active Python environment.
- In those environments, attempting a runtime install can fail before fixture loading reaches test selection.
- Some callers also need a hard opt-out when they manage dependency provisioning themselves.

## 🛠️ Solution

- Treat bare inline dependency names as satisfied when `importlib.metadata` can find an installed distribution.
- Add `TENZIR_TEST_DISABLE_INLINE_DEPENDENCY_INSTALL` to skip inline dependency installation entirely.
- Delay the `uv` lookup until there are actual missing dependencies to install.
- Preserve the existing behavior for versioned requirement strings by default, which still go through `uv`.
- Add tests for the pre-installed bare dependency path, the explicit opt-out, and the versioned requirement path.
- Document the behavior and add an unreleased changelog entry.

## 💬 Review

- The installed-package check is intentionally conservative: only bare package names are skipped.
- The environment variable is a caller-controlled escape hatch; fixture imports can still fail later if required packages are not actually present.
- Requirement specifier handling remains delegated to `uv` unless installation is explicitly disabled.

<sub>
📚 Docs PR: tenzir/docs#361
</sub>